### PR TITLE
Refactor RFT output

### DIFF
--- a/opm/output/eclipse/EclipseWriteRFTHandler.hpp
+++ b/opm/output/eclipse/EclipseWriteRFTHandler.hpp
@@ -31,6 +31,7 @@
 namespace Opm {
     class EclipseGrid;
     class Well;
+    class IOConfig;
 
 namespace EclipseWriterDetails {
 
@@ -41,7 +42,8 @@ namespace EclipseWriterDetails {
     EclipseWriteRFTHandler(const int * compressedToCartesianCellIdx, size_t numCells, size_t cartesianSize);
 
 
-    void writeTimeStep(const std::string& filename,
+    void writeTimeStep(const IOConfig& ioConfig,
+                       const std::string& filename,
                        const ert_ecl_unit_enum ecl_unit,
                        const SimulatorTimerInterface& simulatorTimer,
                        std::vector<std::shared_ptr< const Well >>& wells,

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -1378,7 +1378,8 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
         auto unit_type = eclipseState_->getDeckUnitSystem().getType();
         ert_ecl_unit_enum ecl_unit = convertUnitTypeErtEclUnitEnum(unit_type);
         std::vector<WellConstPtr> wells = eclipseState_->getSchedule()->getWells(timer.reportStepNum());
-        eclipseWriteRFTHandler->writeTimeStep(rft_filename,
+        eclipseWriteRFTHandler->writeTimeStep(*ioConfig,
+                                              rft_filename,
                                               ecl_unit,
                                               timer,
                                               wells,


### PR DESCRIPTION
With this patch the RFT output writer will write a new RFT file for
every simulation, not update in place which was the case previously.

NB: This requires a very new ert: https://github.com/Ensembles/ert/pull/1036
