### PR TITLE
copy the `configure` wrapper from opm-autodiff

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,35 @@
+#!/bin/sh
+# this file is supposed to be located in the source directory
+src_dir=$(dirname $0)
+
+# scan the arguments and set this if build macros could be specified
+mod_dir=
+for OPT in "$@"; do
+    case "$OPT" in
+        --with-opm-common=*)
+            # remove everything before equal sign and assign the rest
+            mod_dir=${OPT#*=}
+            # tilde expansion; note that doing eval may have side effects
+            mod_dir=$(eval echo $mod_dir)
+            # absolute path
+            [ -d "$mod_dir" ] && mod_dir=$(cd $mod_dir ; pwd)
+            ;;
+    esac
+done
+
+# if it isn't specified, the look around in other known places
+conf_file=cmake/Scripts/configure
+if [ -z "$mod_dir" ]; then
+    if [ -r "$src_dir/$conf_file" ]; then
+        mod_dir="$src_dir"
+    fi
+fi
+
+# terminate with error message here if the module directory is not found
+if [ ! -r "$mod_dir/$conf_file" ]; then
+    echo Build macros not located in \"$mod_dir\", use --with-opm-common= to specify! 1>&2
+    exit 1
+fi
+
+# forward to the corresponding script in the cmake/Scripts/ directory
+exec "$mod_dir/$conf_file" --src-dir="$src_dir" "$@"


### PR DESCRIPTION
this enables to build opm-output using an unpatched `dunecontrol` from
Dune 2.3 (and Dune 2.4 if USE_CMAKE is set to "no").

In the medium term the build system needs to become compatible with
Dune's cmake based build system since I think I read somewhere that
the Dune devs intend to remove the autotools based build system before
their next release.
