### PR TITLE
only update a summary file once per report step

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -1390,19 +1390,21 @@ void EclipseWriter::writeTimeStep(const SimulatorTimerInterface& timer,
         free( rft_filename );
     }
 
-    /* Summary variables (well reporting) */
-    // TODO: instead of writing the header (smspec) every time, it should
-    // only be written when there is a change in the well configuration
-    // (first timestep, in practice), and reused later. but how to do this
-    // without keeping the complete summary in memory (which will then
-    // accumulate all the timesteps)?
-    //
-    // Note: The answer to the question above is still not settled, but now we do keep
-    // the complete summary in memory, as a member variable in the EclipseWriter class,
-    // instead of creating a temporary EclipseWriterDetails::Summary in this function
-    // every time it is called.  This has been changed so that the final summary file
-    // will contain data from the whole simulation, instead of just the last step.
-    summary_->writeTimeStep(writeStepIdx_, timer, wellState);
+    if (!isSubstep) {
+        /* Summary variables (well reporting) */
+        // TODO: instead of writing the header (smspec) every time, it should
+        // only be written when there is a change in the well configuration
+        // (first timestep, in practice), and reused later. but how to do this
+        // without keeping the complete summary in memory (which will then
+        // accumulate all the timesteps)?
+        //
+        // Note: The answer to the question above is still not settled, but now we do keep
+        // the complete summary in memory, as a member variable in the EclipseWriter class,
+        // instead of creating a temporary EclipseWriterDetails::Summary in this function
+        // every time it is called.  This has been changed so that the final summary file
+        // will contain data from the whole simulation, instead of just the last step.
+        summary_->writeTimeStep(writeStepIdx_, timer, wellState);
+    }
 
     ++writeStepIdx_;
     // store current report index


### PR DESCRIPTION
this fixes the problem that well totals are off by a factor of about two. (if there are no drastic changes of the well rates during the substeps.) Note that the better solution would be to continue to write once per substep but skipping report step writes if the adaptive time stepper is used. since I've got no idea how to find this out in opm-output I propose this patch as a stop-gap measure.

this superseeds OPM/opm-core#974, OPM/opm-autodiff#613 and OPM/opm-data#95 . (I suppose my main problem there was that the old output files were not overwritten with these PRs and ctest thus compared the a previously computed result of the master versions.)
