### PR TITLE
data::Wells format for simulator data exchange

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -14,6 +14,7 @@ list( APPEND MAIN_SOURCE_FILES
 
 list (APPEND PUBLIC_HEADER_FILES
         opm/output/OutputWriter.hpp
+        opm/output/Wells.hpp
         opm/output/eclipse/CornerpointChopper.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
         opm/output/eclipse/EclipseIOUtil.hpp
@@ -31,6 +32,7 @@ list (APPEND TEST_SOURCE_FILES
         tests/test_EclipseWriteRFTHandler.cpp
         tests/test_writenumwells.cpp
         tests/test_writeReadRestartFile.cpp
+        tests/test_Wells.cpp
 )
 
 # originally generated with the command:

--- a/opm/output/Wells.hpp
+++ b/opm/output/Wells.hpp
@@ -65,6 +65,7 @@ namespace Opm {
 
         private:
             double& get_ref( opt );
+            const double& get_ref( opt ) const;
 
             opt mask = static_cast< opt >( 0 );
 
@@ -90,21 +91,21 @@ namespace Opm {
 
     /* IMPLEMENTATIONS */
 
-    inline bool Rates::has( opt m ) {
+    inline bool Rates::has( opt m ) const {
         const auto mand = static_cast< enum_size >( this->mask )
                         & static_cast< enum_size >( m );
 
         return static_cast< opt >( mand ) == m;
     }
 
-    inline double Rates::get( opt m ) {
+    inline double Rates::get( opt m ) const {
         if( !this->has( m ) )
             throw std::invalid_argument( "Uninitialized value." );
 
         return this->get_ref( m );
     }
 
-    inline double Rates::get( opt m, double default_value ) {
+    inline double Rates::get( opt m, double default_value ) const {
         if( !this->has( m ) ) return default_value;
 
         return this->get_ref( m );
@@ -130,7 +131,7 @@ namespace Opm {
      * This is an implementation detail and understanding this has no
      * significant impact on correct use of the class.
      */
-    inline double& Rates::get_ref( opt m ) {
+    inline const double& Rates::get_ref( opt m ) const {
         switch( m ) {
             case opt::wat: return this->wat;
             case opt::oil: return this->oil;
@@ -143,6 +144,12 @@ namespace Opm {
                 + std::to_string( static_cast< enum_size >( m ) )
                 + "'" );
 
+    }
+
+    inline double& Rates::get_ref( opt m ) {
+        return const_cast< double& >(
+                static_cast< const Rates* >( this )->get_ref( m )
+               );
     }
 
     }

--- a/opm/output/Wells.hpp
+++ b/opm/output/Wells.hpp
@@ -50,14 +50,14 @@ namespace Opm {
             };
 
             /// Query if a value is set.
-            inline bool has( opt );
+            inline bool has( opt ) const;
 
             /// Read the value indicated by m. Throws an exception if
             /// if the requested value is unset.
-            inline double get( opt m );
+            inline double get( opt m ) const;
             /// Read the value indicated by m. Returns a default value if
             /// the requested value is unset.
-            inline double get( opt m, double default_value );
+            inline double get( opt m, double default_value ) const;
             /// Set the value specified by m. Throws an exception if multiple
             /// values are requested. Returns a self-reference to support
             /// chaining.
@@ -86,10 +86,7 @@ namespace Opm {
         std::map< Completion::logical_cartesian_index, Completion > completions;
     };
 
-    struct Wells {
-        double step_length;
-        std::map< std::string, Well > wells;
-    };
+    typedef std::map< std::string, Well > Wells;
 
     /* IMPLEMENTATIONS */
 

--- a/opm/output/Wells.hpp
+++ b/opm/output/Wells.hpp
@@ -1,0 +1,154 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_OUTPUT_WELLS_HPP
+#define OPM_OUTPUT_WELLS_HPP
+
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+    namespace data {
+
+    class Rates {
+        /* Methods are defined inline for performance, as the actual *work* done
+         * is trivial, but somewhat frequent (typically once per time step per
+         * completion per well).
+         *
+         * To add a new rate type, add an entry in the enum with the correct
+         * shift, and if needed, increase the size type. Add a member variable
+         * and a new case in get_ref.
+         */
+
+        public:
+            using enum_size = uint16_t;
+
+            enum class opt : enum_size {
+                wat     = (1 << 0),
+                oil     = (1 << 1),
+                gas     = (1 << 2),
+                polymer = (1 << 3),
+            };
+
+            /// Query if a value is set.
+            inline bool has( opt );
+
+            /// Read the value indicated by m. Throws an exception if
+            /// if the requested value is unset.
+            inline double get( opt m );
+            /// Read the value indicated by m. Returns a default value if
+            /// the requested value is unset.
+            inline double get( opt m, double default_value );
+            /// Set the value specified by m. Throws an exception if multiple
+            /// values are requested. Returns a self-reference to support
+            /// chaining.
+            inline Rates& set( opt m, double value );
+
+        private:
+            double& get_ref( opt );
+
+            opt mask = static_cast< opt >( 0 );
+
+            double wat;
+            double oil;
+            double gas;
+            double polymer;
+    };
+
+    struct Completion {
+        using logical_cartesian_index = size_t;
+        logical_cartesian_index index;
+        Rates rates;
+    };
+
+    struct Well {
+        Rates rates;
+        double bhp;
+        std::map< Completion::logical_cartesian_index, Completion > completions;
+    };
+
+    struct Wells {
+        double step_length;
+        std::map< std::string, Well > wells;
+    };
+
+    /* IMPLEMENTATIONS */
+
+    inline bool Rates::has( opt m ) {
+        const auto mand = static_cast< enum_size >( this->mask )
+                        & static_cast< enum_size >( m );
+
+        return static_cast< opt >( mand ) == m;
+    }
+
+    inline double Rates::get( opt m ) {
+        if( !this->has( m ) )
+            throw std::invalid_argument( "Uninitialized value." );
+
+        return this->get_ref( m );
+    }
+
+    inline double Rates::get( opt m, double default_value ) {
+        if( !this->has( m ) ) return default_value;
+
+        return this->get_ref( m );
+    }
+
+    inline Rates& Rates::set( opt m, double value ) {
+        this->get_ref( m ) = value;
+        /* mask |= m */
+        this->mask = static_cast< opt >(
+                        static_cast< enum_size >( this->mask ) |
+                        static_cast< enum_size >( m )
+                    );
+
+        return *this;
+    }
+
+    /*
+     * To avoid error-prone and repetitve work when extending rates with new
+     * values, the get+set methods use this helper get_ref to determine what
+     * member to manipulate. To add a new option, just add another case
+     * corresponding to the enum entry in Rates to this function.
+     *
+     * This is an implementation detail and understanding this has no
+     * significant impact on correct use of the class.
+     */
+    inline double& Rates::get_ref( opt m ) {
+        switch( m ) {
+            case opt::wat: return this->wat;
+            case opt::oil: return this->oil;
+            case opt::gas: return this->gas;
+            case opt::polymer: return this->polymer;
+        }
+
+        throw std::invalid_argument(
+                "Unknown value type '"
+                + std::to_string( static_cast< enum_size >( m ) )
+                + "'" );
+
+    }
+
+    }
+}
+
+#endif //OPM_OUTPUT_WELLS_HPP

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -1,0 +1,74 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE Wells
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+
+#include <opm/output/Wells.hpp>
+
+using namespace Opm;
+using rt = data::Rates::opt;
+
+BOOST_AUTO_TEST_CASE(has) {
+    data::Rates rates;
+
+    rates.set( rt::wat, 10 );
+    BOOST_CHECK( rates.has( rt::wat ) );
+    BOOST_CHECK( !rates.has( rt::gas ) );
+    BOOST_CHECK( !rates.has( rt::oil ) );
+
+    rates.set( rt::gas, 0 );
+    BOOST_CHECK( rates.has( rt::gas ) );
+    BOOST_CHECK( !rates.has( rt::oil ) );
+}
+
+BOOST_AUTO_TEST_CASE(set_and_get) {
+    data::Rates rates;
+
+    const double wat = 10;
+    const double gas = 10;
+
+    rates.set( rt::wat, wat );
+    rates.set( rt::gas, gas );
+
+    BOOST_CHECK_EQUAL( wat, rates.get( rt::wat ) );
+    BOOST_CHECK_EQUAL( gas, rates.get( rt::gas ) );
+}
+
+BOOST_AUTO_TEST_CASE(get_wrong) {
+    data::Rates rates;
+    const double wat = 10;
+    const double gas = 10;
+
+    rates.set( rt::wat, wat );
+    rates.set( rt::gas, gas );
+
+    const double def = 1;
+
+    BOOST_CHECK_EQUAL( def, rates.get( rt::oil, def ) );
+    BOOST_CHECK_THROW( rates.get( rt::oil ), std::invalid_argument );
+}


### PR DESCRIPTION
Introduces a simple format for data exchange between the simulators and
the the output facilities. Output functions will expect these types, and
it is the simulator's responsibility to create and provide it.

This patch introduces aggregates for well-related information: well
rates, bottom hole pressures and completion rates. Uses a simple bitmask
scheme to differentiate between written values and random garbage.

Supersedes https://github.com/OPM/opm-common/pull/105
