### PR TITLE
Well output support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -7,6 +7,7 @@ list( APPEND MAIN_SOURCE_FILES
         opm/output/eclipse/EclipseReader.cpp
         opm/output/eclipse/EclipseWriteRFTHandler.cpp
         opm/output/eclipse/EclipseWriter.cpp
+        opm/output/eclipse/Summary.cpp
         opm/output/eclipse/writeECLData.cpp
         opm/output/vag/vag.cpp
         opm/output/vtk/writeVtkData.cpp
@@ -22,6 +23,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/output/eclipse/EclipseUnits.hpp
         opm/output/eclipse/EclipseWriteRFTHandler.hpp
         opm/output/eclipse/EclipseWriter.hpp
+        opm/output/eclipse/Summary.hpp
         opm/output/eclipse/writeECLData.hpp
         opm/output/vag/vag.hpp
         opm/output/vtk/writeVtkData.hpp
@@ -33,10 +35,12 @@ list (APPEND TEST_SOURCE_FILES
         tests/test_writenumwells.cpp
         tests/test_writeReadRestartFile.cpp
         tests/test_Wells.cpp
+        tests/test_Summary.cpp
 )
 
 # originally generated with the command:
 # find tests -name '*.xml' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_DATA_FILES
         tests/testBlackoilState3.DATA
+        tests/summary_deck.DATA
 )

--- a/opm/output/Wells.hpp
+++ b/opm/output/Wells.hpp
@@ -84,6 +84,7 @@ namespace Opm {
     struct Well {
         Rates rates;
         double bhp;
+        double thp;
         std::map< Completion::logical_cartesian_index, Completion > completions;
     };
 

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -1,0 +1,502 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/output/eclipse/Summary.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/Units/ConversionFactors.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+namespace Opm {
+
+namespace {
+
+/*
+ * It is VERY important that the dim enum has the same order as the
+ * metric and field arrays. C++ does not support designated initializers, so
+ * this cannot be done in a declaration-order independent matter.
+ */
+
+enum class dim : int {
+    length,
+    time,
+    density,
+    pressure,
+    temperature_absolute,
+    temperature,
+    viscosity,
+    permeability,
+    liquid_surface_volume,
+    gas_surface_volume,
+    volume,
+    liquid_surface_rate,
+    gas_surface_rate,
+    rate,
+    transmissibility,
+    mass,
+};
+
+namespace conversions {
+    /* lookup tables for SI-to-unit system
+     *
+     * We assume that all values in the report structures are plain SI units,
+     * but output can be configured to use other (inconsistent) unit systems.
+     * These lookup tables are passed to the convert function that translates
+     * between SI and the target unit.
+     */
+
+const double metric[] = {
+    1 / Metric::Length,
+    1 / Metric::Time,
+    1 / Metric::Density,
+    1 / Metric::Pressure,
+    1 / Metric::AbsoluteTemperature,
+    1 / Metric::Temperature,
+    1 / Metric::Viscosity,
+    1 / Metric::Permeability,
+    1 / Metric::LiquidSurfaceVolume,
+    1 / Metric::GasSurfaceVolume,
+    1 / Metric::ReservoirVolume,
+    1 / ( Metric::LiquidSurfaceVolume / Metric::Time ),
+    1 / ( Metric::GasSurfaceVolume / Metric::Time ),
+    1 / ( Metric::ReservoirVolume / Metric::Time ),
+    1 / Metric::Transmissibility,
+    1 / Metric::Mass,
+};
+
+const double field[] = {
+    1 / Field::Length,
+    1 / Field::Time,
+    1 / Field::Density,
+    1 / Field::Pressure,
+    1 / Field::AbsoluteTemperature,
+    1 / Field::Temperature,
+    1 / Field::Viscosity,
+    1 / Field::Permeability,
+    1 / Field::LiquidSurfaceVolume,
+    1 / Field::GasSurfaceVolume,
+    1 / Field::ReservoirVolume,
+    1 / ( Field::LiquidSurfaceVolume / Field::Time ),
+    1 / ( Field::GasSurfaceVolume / Field::Time ),
+    1 / ( Field::ReservoirVolume / Field::Time ),
+    1 / Field::Transmissibility,
+    1 / Field::Mass,
+};
+
+}
+
+/*
+ * A series of helper functions to read & compute values from the simulator,
+ * intended to clean up the keyword -> action mapping in the *_keyword
+ * functions.
+ */
+
+inline double convert( double si_val, dim d, const double* table ) {
+    return si_val * table[ static_cast< int >( d ) ];
+}
+
+using rt = data::Rates::opt;
+
+/* posix_time -> time_t isn't in older versions of boost (at least not in
+ * 1.53), so it's implemented here
+ */
+inline std::time_t to_time_t( boost::posix_time::ptime pt ) {
+    auto dur = pt - boost::posix_time::ptime( boost::gregorian::date( 1970, 1, 1 ) );
+    return std::time_t( dur.total_seconds() );
+}
+
+/* The supported Eclipse keywords */
+enum class E {
+    WBHP,
+    WBHPH,
+    WGIR,
+    WGIRH,
+    WGIT,
+    WGITH,
+    WGOR,
+    WGORH,
+    WGPR,
+    WGPRH,
+    WGPT,
+    WGPTH,
+    WLPR,
+    WLPRH,
+    WLPT,
+    WLPTH,
+    WOIR,
+    WOIRH,
+    WOIT,
+    WOITH,
+    WOPR,
+    WOPRH,
+    WOPT,
+    WOPTH,
+    WTHP,
+    WTHPH,
+    WWCT,
+    WWCTH,
+    WWIR,
+    WWIRH,
+    WWIT,
+    WWITH,
+    WWPR,
+    WWPRH,
+    WWPT,
+    WWPTH,
+    UNSUPPORTED,
+};
+
+const std::map< std::string, E > keyhash = {
+    { "WBHP",  E::WBHP },
+    { "WBHPH", E::WBHPH },
+    { "WGIR",  E::WGIR },
+    { "WGIRH", E::WGIRH },
+    { "WGIT",  E::WGIT },
+    { "WGITH", E::WGITH },
+    { "WGOR",  E::WGOR },
+    { "WGORH", E::WGORH },
+    { "WGPR",  E::WGPR },
+    { "WGPRH", E::WGPRH },
+    { "WGPT",  E::WGPT },
+    { "WGPTH", E::WGPTH },
+    { "WLPR",  E::WLPR },
+    { "WLPRH", E::WLPRH },
+    { "WLPT",  E::WLPT },
+    { "WLPTH", E::WLPTH },
+    { "WOIR",  E::WOIR },
+    { "WOIRH", E::WOIRH },
+    { "WOIT",  E::WOIT },
+    { "WOITH", E::WOITH },
+    { "WOPR",  E::WOPR },
+    { "WOPRH", E::WOPRH },
+    { "WOPT",  E::WOPT },
+    { "WOPTH", E::WOPTH },
+    { "WTHP",  E::WTHP },
+    { "WTHPH", E::WTHPH },
+    { "WWCT",  E::WWCT },
+    { "WWCTH", E::WWCTH },
+    { "WWIR",  E::WWIR },
+    { "WWIRH", E::WWIRH },
+    { "WWIT",  E::WWIT },
+    { "WWITH", E::WWITH },
+    { "WWPR",  E::WWPR },
+    { "WWPRH", E::WWPRH },
+    { "WWPT",  E::WWPT },
+    { "WWPTH", E::WWPTH },
+};
+
+inline const E khash( const char* key ) {
+    /* Since a switch is used to determine the proper computation from the
+     * input node, but keywords are stored as strings, we need a string -> enum
+     * mapping for keywords.
+     */
+    auto itr = keyhash.find( key );
+    if( itr == keyhash.end() ) return E::UNSUPPORTED;
+    return itr->second;
+}
+
+inline double wwct( double wat, double oil ) {
+    /* handle div-by-zero - if this well is shut, all production rates will be
+     * zero and there is no cut (i.e. zero). */
+    if( oil == 0 ) return 0;
+
+    return wat / ( wat + oil );
+}
+
+inline double wwcth( const Well& w, size_t ts ) {
+    /* From our point of view, injectors don't have meaningful water cuts. */
+    if( w.isInjector( ts ) ) return 0;
+
+    const auto& p = w.getProductionProperties( ts );
+    return wwct( p.WaterRate, p.OilRate );
+}
+
+inline double wgor( double gas, double oil ) {
+    /* handle div-by-zero - if this well is shut, all production rates will be
+     * zero and there is no gas/oil ratio, (i.e. zero). 
+     *
+     * Also, if this is a gas well that produces no oil, gas/oil ratio would be
+     * undefined and is explicitly set to 0. This is the author's best guess.
+     * If other semantics when just gas is produced, this must be changed.
+     */
+    if( oil == 0 ) return 0;
+
+    return gas / oil;
+}
+
+inline double wgorh( const Well& w, size_t ts ) {
+    /* We do not support mixed injections, and gas/oil is undefined when oil is
+     * zero (i.e. pure gas injector), so always output 0 if this is an injector
+     */
+    if( w.isInjector( ts ) ) return 0;
+
+    const auto& p = w.getProductionProperties( ts );
+
+    return wgor( p.GasRate, p.OilRate );
+}
+
+enum class WT { wat, oil, gas };
+inline double prodrate( const Well& w,
+                        size_t timestep,
+                        WT wt,
+                        const double* conversion_table ) {
+    if( !w.isProducer( timestep ) ) return 0;
+
+    const auto& p = w.getProductionProperties( timestep );
+    switch( wt ) {
+        case WT::wat: return convert( p.WaterRate, dim::liquid_surface_rate, conversion_table );
+        case WT::oil: return convert( p.OilRate, dim::liquid_surface_rate, conversion_table );
+        case WT::gas: return convert( p.GasRate, dim::gas_surface_rate, conversion_table );
+    }
+
+    throw std::runtime_error( "Reached impossible state in prodrate" );
+}
+
+inline double prodvol( const Well& w,
+                       size_t timestep,
+                       WT wt,
+                       const double* conversion_table ) {
+    const auto rate = prodrate( w, timestep, wt, conversion_table );
+    return rate * convert( 1, dim::time, conversion_table );
+}
+
+inline double injerate( const Well& w,
+                        size_t timestep,
+                        WellInjector::TypeEnum wt,
+                        const double* conversion_table ) {
+
+    if( !w.isInjector( timestep ) ) return 0;
+    const auto& i = w.getInjectionProperties( timestep );
+
+    /* we don't support mixed injectors, so querying a water injector for
+     * gas rate gives 0.0
+     */
+    if( wt != i.injectorType ) return 0;
+
+    if( wt == WellInjector::GAS )
+        return convert( i.surfaceInjectionRate, dim::gas_surface_rate, conversion_table );
+
+    return convert( i.surfaceInjectionRate, dim::liquid_surface_rate, conversion_table );
+}
+
+inline double injevol( const Well& w,
+                       size_t timestep,
+                       WellInjector::TypeEnum wt,
+                       const double* conversion_table ) {
+
+    const auto rate = injerate( w, timestep, wt, conversion_table );
+    return rate * convert( 1, dim::time, conversion_table );
+}
+
+inline double get_rate( const data::Well& w,
+                        rt phase,
+                        const double* conversion_table ) {
+    const auto x = w.rates.get( phase, 0.0 );
+
+    switch( phase ) {
+        case rt::gas: return convert( x, dim::gas_surface_rate, conversion_table );
+        default: return convert( x, dim::liquid_surface_rate, conversion_table );
+    }
+}
+
+inline double get_vol( const data::Well& w,
+                       rt phase,
+                       const double* conversion_table ) {
+    const auto x = w.rates.get( phase, 0.0 );
+    switch( phase ) {
+        case rt::gas: return convert( x, dim::gas_surface_volume, conversion_table );
+        default: return convert( x, dim::liquid_surface_volume, conversion_table );
+    }
+}
+
+inline double well_keywords( const smspec_node_type* node,
+                             const ecl_sum_tstep_type* prev,
+                             const double* conversion_table,
+                             const data::Well& sim_well,
+                             const Well& state_well,
+                             size_t tstep ) {
+
+    const auto* genkey = smspec_node_get_gen_key1( node );
+    const auto accu = prev ? ecl_sum_tstep_get_from_key( prev, genkey ) : 0;
+
+    switch( khash( smspec_node_get_keyword( node ) ) ) {
+
+        /* Production rates */
+        case E::WWPR: return get_rate( sim_well, rt::wat, conversion_table );
+        case E::WOPR: return get_rate( sim_well, rt::oil, conversion_table );
+        case E::WGPR: return get_rate( sim_well, rt::gas, conversion_table );
+        case E::WLPR: return get_rate( sim_well, rt::wat, conversion_table )
+                           + get_rate( sim_well, rt::oil, conversion_table );
+
+        /* Production totals */
+        case E::WWPT: return accu + get_vol( sim_well, rt::wat, conversion_table );
+        case E::WOPT: return accu + get_vol( sim_well, rt::oil, conversion_table );
+        case E::WGPT: return accu + get_vol( sim_well, rt::gas, conversion_table );
+        case E::WLPT: return accu + get_vol( sim_well, rt::wat, conversion_table )
+                                  + get_vol( sim_well, rt::oil, conversion_table );
+
+        /* Production history rates */
+        case E::WWPRH: return prodrate( state_well, tstep, WT::wat, conversion_table );
+        case E::WOPRH: return prodrate( state_well, tstep, WT::oil, conversion_table );
+        case E::WGPRH: return prodrate( state_well, tstep, WT::gas, conversion_table );
+        case E::WLPRH: return prodrate( state_well, tstep, WT::wat, conversion_table ) +
+                              prodrate( state_well, tstep, WT::oil, conversion_table );
+
+        /* Production history totals */
+        case E::WWPTH: return accu + prodvol( state_well, tstep, WT::wat, conversion_table );
+        case E::WOPTH: return accu + prodvol( state_well, tstep, WT::oil, conversion_table );
+        case E::WGPTH: return accu + prodvol( state_well, tstep, WT::gas, conversion_table );
+        case E::WLPTH: return accu + prodvol( state_well, tstep, WT::wat, conversion_table ) +
+                                     prodvol( state_well, tstep, WT::oil, conversion_table );
+
+        /* Production ratios */
+        case E::WWCT: return wwct( get_rate( sim_well, rt::wat, conversion_table ),
+                                   get_rate( sim_well, rt::oil, conversion_table ) );
+
+        case E::WWCTH: return wwcth( state_well, tstep );
+
+        case E::WGOR: return wgor( get_rate( sim_well, rt::gas, conversion_table ),
+                                   get_rate( sim_well, rt::oil, conversion_table ) );
+        case E::WGORH: return wgorh( state_well, tstep );
+
+        /* Pressures */
+        case E::WBHP: return convert( sim_well.bhp, dim::pressure, conversion_table );
+        case E::WBHPH: return 0; /* not supported */
+
+        case E::WTHP: return convert( sim_well.thp, dim::pressure, conversion_table );
+        case E::WTHPH: return 0; /* not supported */
+
+        /* Injection rates */
+        /* TODO: read from sim or compute (how?) */
+        /* TODO: Tests */
+        case E::WWIR: return -1 * (get_rate( sim_well, rt::wat, conversion_table ));
+        case E::WOIR: return -1 * (get_rate( sim_well, rt::oil, conversion_table ));
+        case E::WGIR: return -1 * (get_rate( sim_well, rt::gas, conversion_table ));
+        case E::WWIT: return accu - get_vol( sim_well, rt::wat, conversion_table );
+        case E::WOIT: return accu - get_vol( sim_well, rt::oil, conversion_table );
+        case E::WGIT: return accu - get_vol( sim_well, rt::gas, conversion_table );
+
+        case E::WWIRH: return injerate( state_well, tstep, WellInjector::WATER, conversion_table );
+        case E::WOIRH: return injerate( state_well, tstep, WellInjector::GAS, conversion_table );
+        case E::WGIRH: return injerate( state_well, tstep, WellInjector::OIL, conversion_table );
+
+        case E::WWITH: return accu + injevol( state_well, tstep, WellInjector::WATER, conversion_table );
+        case E::WOITH: return accu + injevol( state_well, tstep, WellInjector::GAS, conversion_table );
+        case E::WGITH: return accu + injevol( state_well, tstep, WellInjector::OIL, conversion_table );
+
+        case E::UNSUPPORTED:
+        default:
+            return 0;
+    }
+}
+
+}
+
+namespace out {
+
+Summary::Summary( const EclipseState& st, const SummaryConfig& sum ) :
+    Summary( st, sum, st.getTitle().c_str() )
+{}
+
+Summary::Summary( const EclipseState& st,
+                const SummaryConfig& sum,
+                const std::string& basename ) :
+    Summary( st, sum, basename.c_str() )
+{}
+
+static inline const double* get_conversions( const EclipseState& es ) {
+    using namespace conversions;
+
+    switch( es.getDeckUnitSystem().getType() ) {
+        case UnitSystem::UNIT_TYPE_METRIC: return metric;
+        case UnitSystem::UNIT_TYPE_FIELD: return field;
+        default: return metric;
+    }
+}
+
+Summary::Summary( const EclipseState& st,
+                  const SummaryConfig& sum,
+                  const char* basename ) :
+    ecl_sum( 
+            ecl_sum_alloc_writer( 
+                basename,
+                st.getIOConfig()->getFMTOUT(),
+                st.getIOConfig()->getUNIFOUT(),
+                ":",
+                to_time_t( st.getSchedule()->getStartTime() ),
+                true,
+                st.getInputGrid()->getNX(),
+                st.getInputGrid()->getNY(),
+                st.getInputGrid()->getNZ()
+                )
+            ),
+    conversions( get_conversions( st ) )
+{
+    for( const auto& node : sum ) {
+        auto* nodeptr = ecl_sum_add_var( this->ecl_sum.get(), node.keyword(),
+                                            node.wgname(), node.num(), "", 0 );
+
+        switch( smspec_node_get_var_type( nodeptr ) ) {
+            case ECL_SMSPEC_WELL_VAR:
+                this->wvar[ node.wgname() ].push_back( nodeptr );
+                break;
+
+            default:
+                break;
+        }
+    }
+}
+
+void Summary::add_timestep( int report_step,
+                            double step_duration,
+                            const EclipseState& es,
+                            const data::Wells& wells ) {
+    this->duration += step_duration;
+    auto* tstep = ecl_sum_add_tstep( this->ecl_sum.get(), report_step, this->duration );
+
+    /* calculate the values for the Well-family of keywords. */
+    for( const auto& pair : this->wvar ) {
+        const auto* wname = pair.first;
+
+        const auto& state_well = es.getSchedule()->getWell( wname );
+        const auto& sim_well = wells.at( wname );
+
+        for( const auto* node : pair.second ) {
+            auto val = well_keywords( node, this->prev_tstep,
+                                      this->conversions, sim_well,
+                                      state_well, report_step );
+            ecl_sum_tstep_set_from_node( tstep, node, val );
+        }
+    }
+
+    this->prev_tstep = tstep;
+}
+
+void Summary::write() {
+    ecl_sum_fwrite( this->ecl_sum.get() );
+}
+
+}
+
+}

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -1,0 +1,59 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_OUTPUT_SUMMARY_HPP
+#define OPM_OUTPUT_SUMMARY_HPP
+
+#include <string>
+#include <vector>
+
+#include <ert/ecl/ecl_sum.h>
+#include <ert/util/ert_unique_ptr.hpp>
+
+#include <opm/output/Wells.hpp>
+
+namespace Opm {
+
+    class EclipseState;
+    class SummaryConfig;
+
+namespace out {
+
+class Summary {
+    public:
+        Summary( const EclipseState&, const SummaryConfig& );
+        Summary( const EclipseState&, const SummaryConfig&, const std::string& );
+        Summary( const EclipseState&, const SummaryConfig&, const char* basename );
+
+        void add_timestep( int report_step, double step_duration,
+                           const EclipseState&, const data::Wells& );
+        void write();
+
+    private:
+        ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > ecl_sum;
+        std::map< const char*, std::vector< smspec_node_type* > > wvar;
+        const ecl_sum_tstep_type* prev_tstep = nullptr;
+        double duration = 0;
+        const double* conversions;
+};
+
+}
+}
+
+#endif //OPM_OUTPUT_SUMMARY_HPP

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -1,0 +1,275 @@
+-- Synthetic test deck based on Norne. This data set is meant to be a simple,
+-- well-documented deck for the behaviour of SUMMARY specified output. Data
+-- is mostly entered to *traceable* and does not necessarily make sense from
+-- a simulation point of view.
+
+START
+10 MAI 2007 / 
+RUNSPEC
+
+TITLE
+SUMMARYTESTS
+ 
+-- A simple 10x10x10 cube. Simple to reason about, large enough for all tests
+DIMENS
+ 10 10 10 /
+
+GRID
+
+SUMMARY
+DATE
+PERFORMA
+--
+-- Field Data
+-- Production Rates
+FVPR
+FWPR
+FWPRH
+FOPR
+FOPRH
+FGPR
+FGPRH
+FLPR
+FLPRH
+FGSR
+FGCR
+--FTPRSEA
+-- Injection Rates
+FVIR
+FWIR
+FWIRH
+FGIR
+FGIRH
+-- Production Cummulatives
+FVPT
+FWPT
+FOPT
+FLPT
+FLPTH
+FGPT
+FOPTH
+FGPTH
+FWPTH
+FGST
+FGCT
+-- Injection Cummulatives
+FVIT
+FWIT
+FWITH
+FGIT
+FGITH
+-- In place
+FWIP
+FOIP
+FGIP
+-- Ratios
+FWCT
+FWCTH
+FGOR
+FGORH
+-- Pressures
+FPR
+--BPR
+--18 63 25 /
+--18 63 26 /
+--/
+--  Region data
+RPR
+/
+ROPT
+/
+RGPT
+/
+RWPT
+/
+RGFT
+/
+RWFT
+/
+ROIP
+/
+ROP
+/
+--  Group data --
+GPR -- group nodal pressure
+/
+GOPT -- group oil production total
+/
+GGPT -- group gas production total
+/
+GWPT -- group water production total
+/
+GOPR -- group oil production rate
+/
+GLPR -- group liquid production rate
+/
+GGPR -- group gas production rate
+/
+GWPR -- group water production rate
+/
+GGIR -- group gas injection rate
+/
+GGIT -- grouop gas injection total
+/
+GWCT -- group water cut
+/
+GGOR -- group gas oil ration
+/
+GWIR -- group water injection rate
+/
+-- Well Data
+-- Production Rates
+WWPR
+/
+WWPRH
+/
+WOPR
+/
+WOPRH
+/
+WGPR
+/
+WGPRH
+/
+WLPR
+/
+WLPRH
+/
+
+WLPT
+/
+
+WLPTH
+/
+
+-- Injection Rates
+WWIR
+ W_3
+/
+WWIRH
+  W_3
+/
+
+WGIR
+  W_3
+/
+
+WGIRH
+  W_3
+/
+
+WGIT
+  W_3
+/
+
+WGIRH
+  W_3
+/
+
+-- Production Cummulatives
+WWPT
+/
+WWPTH
+/
+WOPT
+/
+WOPTH
+/
+WGPT
+/
+WGPTH
+/
+-- Tracers
+--WTPRSEA
+--/
+--WTPTSEA
+--/
+-- Injection Cummulatives
+WWIT
+  W_3
+/
+-- Ratios
+WWCT
+/
+WWCTH
+/
+WGOR
+/
+WGORH
+/
+
+-- Performance
+WBHP
+/
+WBHPH
+/
+WTHP
+/
+WTHPH
+/
+WPI
+/
+WBP
+/
+WBP4
+/
+-- Water injection per connection
+----CWIR
+----'F-1H' /
+----'F-2H' /
+----'F-3H' /
+----'F-4H' /
+----'C-1H' /
+----'C-2H' /
+----'C-3H' /
+----'C-4H' /
+----/
+----CWIT
+----'F-1H' /
+----'F-2H' /
+----'F-3H' /
+----'F-4H' /
+----'C-1H' /
+----'C-2H' /
+----'C-3H' /
+----'C-4H' /
+----/
+---- Connection production rates
+----CGPT
+----'E-4AH' /
+----/
+----CGFR
+----'E-4AH' /
+----/
+----CWFR
+----'E-2H' /
+----/
+
+SCHEDULE
+
+-- Three wells, two producers (so that we can form a group) and one injector
+WELSPECS
+     'W_1'        'G_1'   30   37  3.33       'OIL'  7* /   
+     'W_2'        'G_1'   30   37  3.33       'OIL'  7* /   
+     'W_3'        'G_2'   20   51  3.92       'WATER'  7* /  
+/
+
+WCONHIST
+-- history rates are set so that W_1 produces 1, W_2 produces 2 etc.
+-- index.offset.
+-- organised as oil-water-gas
+    W_1 SHUT ORAT 10.1 10 10.2 /
+    W_2 SHUT ORAT 20.1 20 20.2 /
+/
+
+WCONINJH
+-- Injection historical rates (water only, as we only support pure injectors)
+    W_3 WATER STOP 259200 /
+/
+
+TSTEP
+-- register time steps (in days). This allows us to write *two* report steps (1
+-- and 2. Without this, totals/accumulations would fail (segfault) when looking
+-- up historical rates and volumes. These volumes however don't change, i.e.
+-- every time step has the same set of values
+10 10 /

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1,0 +1,358 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE Wells
+#include <boost/test/unit_test.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <stdexcept>
+
+#include <ert/ecl/ecl_sum.h>
+
+#include <opm/output/Wells.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+using namespace Opm;
+using rt = data::Rates::opt;
+
+const char* path = "summary_deck.DATA";
+
+/* conversion factor for whenever 'day' is the unit of measure, whereas we
+ * expect input in SI units (seconds)
+ */
+static const int day = 24 * 60 * 60;
+
+static data::Wells result_wells() {
+    /* populate with the following pattern:
+     *
+     * Wells are named W_1, W_2 etc, i.e. wells are 1 indexed.
+     *
+     * rates on a well are populated with 10 * wellidx . type (where type is
+     * 0-1-2 from owg)
+     *
+     * bhp is wellidx.1
+     * bhp is wellidx.2
+     *
+     * completions are 100*wellidx . type
+     */
+
+    // conversion factor Pascal (simulator output) <-> barsa
+    const double ps = 100000;
+
+    data::Rates rates1;
+    rates1.set( rt::wat, 10.0 / day );
+    rates1.set( rt::oil, 10.1 / day );
+    rates1.set( rt::gas, 10.2 / day );
+
+    data::Rates rates2;
+    rates2.set( rt::wat, 20.0 / day );
+    rates2.set( rt::oil, 20.1 / day );
+    rates2.set( rt::gas, 20.2 / day );
+
+    data::Rates rates3;
+    rates3.set( rt::wat, 30.0 / day );
+    rates3.set( rt::oil, 30.1 / day );
+    rates3.set( rt::gas, 30.2 / day );
+
+    data::Well well1 { rates1, 0.1 * ps, 0.2 * ps, {} };
+    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, {} };
+    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, {} };
+
+    return { { "W_1", well1 }, { "W_2", well2 }, { "W_3", well3 } };
+}
+
+ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > readsum( const std::string& base ) {
+    return ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free >(
+            ecl_sum_fread_alloc_case( base.c_str(), ":" )
+           );
+}
+
+void rmfiles( const std::string& basename ) {
+    std::remove( ( basename + ".UNSMRY" ).c_str() );
+    std::remove( ( basename + ".SMSPEC" ).c_str() );
+}
+
+struct setup {
+    std::shared_ptr< Deck > deck;
+    EclipseState es;
+    SummaryConfig config;
+    data::Wells wells;
+    std::string name;
+
+    setup( const std::string& fname ) :
+        deck( Parser().parseFile( path, ParseContext() ) ),
+        es( deck, ParseContext() ),
+        config( *deck, es ),
+        wells( result_wells() ),
+        name( fname )
+    {}
+};
+
+/*
+ * Tests works by reading the Deck, write the summary output, then immediately
+ * read it again (with ERT), and compare the read values with the input.
+ */
+BOOST_AUTO_TEST_CASE(W_WOG_PR) {
+    setup cfg( "sum_test_W_WOG_PR" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+    BOOST_CHECK_CLOSE( 10.0, ecl_sum_get_well_var( resp, 0, "W_1", "WWPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.0, ecl_sum_get_well_var( resp, 0, "W_2", "WWPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_well_var( resp, 0, "W_3", "WWPR" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.1, ecl_sum_get_well_var( resp, 0, "W_1", "WOPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.1, ecl_sum_get_well_var( resp, 0, "W_2", "WOPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.1, ecl_sum_get_well_var( resp, 0, "W_3", "WOPR" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.2, ecl_sum_get_well_var( resp, 0, "W_1", "WGPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.2, ecl_sum_get_well_var( resp, 0, "W_2", "WGPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_well_var( resp, 0, "W_3", "WGPR" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(W_WOG_PT) {
+    setup cfg( "sum_test_W_WOG_PT" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.add_timestep( 2, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+    BOOST_CHECK_CLOSE( 10.0 / day, ecl_sum_get_well_var( resp, 0, "W_1", "WWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.0 / day, ecl_sum_get_well_var( resp, 0, "W_2", "WWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0 / day, ecl_sum_get_well_var( resp, 0, "W_3", "WWPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.1 / day, ecl_sum_get_well_var( resp, 0, "W_1", "WOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.1 / day, ecl_sum_get_well_var( resp, 0, "W_2", "WOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.1 / day, ecl_sum_get_well_var( resp, 0, "W_3", "WOPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.2 / day, ecl_sum_get_well_var( resp, 0, "W_1", "WGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.2 / day, ecl_sum_get_well_var( resp, 0, "W_2", "WGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2 / day, ecl_sum_get_well_var( resp, 0, "W_3", "WGPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 2 * 10.0 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.0 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 30.0 / day, ecl_sum_get_well_var( resp, 1, "W_3", "WWPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 2 * 10.1 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.1 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 30.1 / day, ecl_sum_get_well_var( resp, 1, "W_3", "WOPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 2 * 10.2 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.2 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 30.2 / day, ecl_sum_get_well_var( resp, 1, "W_3", "WGPT" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(WWCT) {
+    setup cfg( "sum_test_WWCT" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    const double wcut1 = 10.0 / ( 10.0 + 10.1 );
+    const double wcut2 = 20.0 / ( 20.0 + 20.1 );
+    const double wcut3 = 30.0 / ( 30.0 + 30.1 );
+
+    BOOST_CHECK_CLOSE( wcut1, ecl_sum_get_well_var( resp, 0, "W_1", "WWCT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( wcut2, ecl_sum_get_well_var( resp, 0, "W_2", "WWCT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( wcut3, ecl_sum_get_well_var( resp, 0, "W_3", "WWCT" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(WGOR) {
+    setup cfg( "sum_test_WGOR" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    const double wgor1 = 10.2 / 10.1;
+    const double wgor2 = 20.2 / 20.1;
+    const double wgor3 = 30.2 / 30.1;
+
+    BOOST_CHECK_CLOSE( wgor1, ecl_sum_get_well_var( resp, 0, "W_1", "WGOR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( wgor2, ecl_sum_get_well_var( resp, 0, "W_2", "WGOR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( wgor3, ecl_sum_get_well_var( resp, 0, "W_3", "WGOR" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(WBHP) {
+    setup cfg( "sum_test_WBHP" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE( 0.1, ecl_sum_get_well_var( resp, 0, "W_1", "WBHP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 1.1, ecl_sum_get_well_var( resp, 0, "W_2", "WBHP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.1, ecl_sum_get_well_var( resp, 0, "W_3", "WBHP" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(WTHP) {
+    setup cfg( "sum_test_TBHP" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE( 0.2, ecl_sum_get_well_var( resp, 0, "W_1", "WTHP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 1.2, ecl_sum_get_well_var( resp, 0, "W_2", "WTHP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.2, ecl_sum_get_well_var( resp, 0, "W_3", "WTHP" ), 1e-5 );
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(WLP_R_T) {
+    setup cfg( "sum_test_WLP_R_T" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE( 10.0 + 10.1, ecl_sum_get_well_var( resp, 0, "W_1", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (10.0 + 10.1) / day, ecl_sum_get_well_var( resp, 0, "W_1", "WLPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.0 + 10.1, ecl_sum_get_well_var( resp, 1, "W_1", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.0 + 10.1) / day, ecl_sum_get_well_var( resp, 1, "W_1", "WLPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 20.0 + 20.1, ecl_sum_get_well_var( resp, 0, "W_2", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (20.0 + 20.1) / day, ecl_sum_get_well_var( resp, 0, "W_2", "WLPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.0 + 20.1, ecl_sum_get_well_var( resp, 1, "W_2", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (20.0 + 20.1) / day, ecl_sum_get_well_var( resp, 1, "W_2", "WLPT" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 30.0 + 30.1, ecl_sum_get_well_var( resp, 0, "W_3", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (30.0 + 30.1) / day, ecl_sum_get_well_var( resp, 0, "W_3", "WLPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (30.0 + 30.1), ecl_sum_get_well_var( resp, 1, "W_3", "WLPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.0 + 30.1) / day, ecl_sum_get_well_var( resp, 1, "W_3", "WLPT" ), 1e-5 );
+
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(W_WOG_PRH) {
+    setup cfg( "sum_test_W_WOG_PRH" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE( 10, ecl_sum_get_well_var( resp, 0, "W_1", "WWPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20, ecl_sum_get_well_var( resp, 0, "W_2", "WWPRH" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.1, ecl_sum_get_well_var( resp, 0, "W_1", "WOPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.1, ecl_sum_get_well_var( resp, 0, "W_2", "WOPRH" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 10.2, ecl_sum_get_well_var( resp, 0, "W_1", "WGPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.2, ecl_sum_get_well_var( resp, 0, "W_2", "WGPRH" ), 1e-5 );
+
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(W_WOG_PTH) {
+    setup cfg( "sum_test_W_WOG_PRH" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 1, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE( 2 * 10.0 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WWPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.0 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WWPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 10.1 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WOPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.1 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WOPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 10.2 / day, ecl_sum_get_well_var( resp, 1, "W_1", "WGPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 20.2 / day, ecl_sum_get_well_var( resp, 1, "W_2", "WGPTH" ), 1e-5 );
+
+    rmfiles( cfg.name );
+}
+
+BOOST_AUTO_TEST_CASE(Time) {
+    setup cfg( "sum_test_Time" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 5 *  day, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 5 *  day, cfg.es, cfg.wells );
+    writer.add_timestep( 2, 10 * day, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    BOOST_CHECK( ecl_sum_has_report_step( resp, 1 ) );
+    BOOST_CHECK( ecl_sum_has_report_step( resp, 2 ) );
+    BOOST_CHECK( !ecl_sum_has_report_step( resp, 3 ) );
+
+    BOOST_CHECK_EQUAL( ecl_sum_iget_sim_days( resp, 0 ), 5 );
+    BOOST_CHECK_EQUAL( ecl_sum_iget_sim_days( resp, 1 ), 10 );
+    BOOST_CHECK_EQUAL( ecl_sum_iget_sim_days( resp, 2 ), 20 );
+    BOOST_CHECK_EQUAL( ecl_sum_get_sim_length( resp ), 20 );
+}
+
+BOOST_AUTO_TEST_CASE(WRITE) {
+    const auto deck = Parser().parseFile( path, ParseContext() );
+    EclipseState es( deck, ParseContext() );
+    SummaryConfig config( *deck, es );
+    const auto wells = result_wells();
+
+    out::Summary writer( es, config );
+    writer.add_timestep( 1, 1, es, wells );
+    writer.add_timestep( 1, 1, es, wells );
+    writer.write();
+}


### PR DESCRIPTION
Alright, looks like we're approaching a usable state here.

First iteration of user-controlled results output. ERT does most of the heavy lifting, and this patch enables easier use & management from OPM. Comes with a test suite of (most) of the Well-oriented keywords from Norne.

Notable details:
- Intended to be largely invisible to client code, with the notable exception of the timesteps in the simulator (which obviously needs to feed it data for every step).
- It's somewhat `dump-and-forget`, but due to both ERT behaviour and the general behaviour of the SUMMARY format this isn't too bad.
- Unit support (read from EclipseState).

Bugs/needs-for-improvement:
- Doesn't support WPI/WBP/WPB4 as I don't know how to calculate this. @totto82 Could you maybe be of assistance here?
- I'm not certain how we plan to model injector/producer. Currently I assume that if a well is a producer, rates will be positive, and if it is an injector, rates will be negative. The simulator might (probably) views this the other way around, or want to have a dedicated field for injection rates - feedback welcome.
