### PR TITLE
Const has no effect in by-value return.

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -264,7 +264,7 @@ const std::map< std::string, E > keyhash = {
     { "GGOR",  E::GGOR },
 };
 
-inline const E khash( const char* key ) {
+inline E khash( const char* key ) {
     /* Since a switch is used to determine the proper computation from the
      * input node, but keywords are stored as strings, we need a string -> enum
      * mapping for keywords.


### PR DESCRIPTION
Another minor warning silenced.
