### PR TITLE
added: downstream build support in the jenkins trigger

### DIFF
--- a/jenkins/build-opm-output.sh
+++ b/jenkins/build-opm-output.sh
@@ -40,23 +40,13 @@ function build_opm_output {
   test $? -eq 0 || exit 1
   popd
 
-  # Build opm-parser
-  clone_and_build_module opm-parser "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_PARSER_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
-
-  # Build opm-material
-  clone_and_build_module opm-material "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_MATERIAL_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
-
-  # Build opm-core
-  clone_and_build_module opm-core "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_CORE_REVISION $WORKSPACE/serial
-  test $? -eq 0 || exit 1
+  build_upstreams
 
   # Build opm-output
   pushd .
   mkdir serial/build-opm-output
   cd serial/build-opm-output
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -2,11 +2,18 @@
 
 source `dirname $0`/build-opm-output.sh
 
+declare -a upstreams
+upstreams=(opm-parser
+           opm-material
+           opm-core)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+upstreamRev[opm-material]=master
+upstreamRev[opm-core]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
-OPM_MATERIAL_REVISION=master
-OPM_CORE_REVISION=master
 
 build_opm_output
 test $? -eq 0 || exit 1


### PR DESCRIPTION
use 'jenkins build this with downstreams please'.

this will build all downstreams against the PR, and
execute their tests. PR's for upstream and downstream modules
can be specified.

the aggregated test results are attached to the job result on jenkins.

depends on https://github.com/OPM/opm-common/pull/111
