### PR TITLE
Added support for writing NNC information

### DIFF
--- a/opm/output/OutputWriter.cpp
+++ b/opm/output/OutputWriter.cpp
@@ -26,9 +26,9 @@ struct MultiWriter : public OutputWriter {
     MultiWriter (ptr_t writers) : writers_ (std::move (writers)) { }
 
     /// Forward the call to all writers
-    virtual void writeInit(const SimulatorTimerInterface &timer) {
+    virtual void writeInit(const SimulatorTimerInterface &timer, const NNC& nnc) {
         for (it_t it = writers_->begin (); it != writers_->end (); ++it) {
-            (*it)->writeInit (timer);
+            (*it)->writeInit (timer, nnc);
         }
     }
 

--- a/opm/output/OutputWriter.hpp
+++ b/opm/output/OutputWriter.hpp
@@ -22,6 +22,7 @@
 
 #include <memory>  // unique_ptr, shared_ptr
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
 struct UnstructuredGrid;
 
@@ -73,7 +74,7 @@ public:
      * This routine should be called before the first timestep (i.e. when
      * timer.currentStepNum () == 0)
      */
-    virtual void writeInit(const SimulatorTimerInterface &timer) = 0;
+    virtual void writeInit(const SimulatorTimerInterface &timer, const NNC& nnc = NNC()) = 0;
 
     /*!
      * \brief Write a blackoil reservoir state to disk for later inspection with

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -42,6 +42,7 @@
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Units/ConversionFactors.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
@@ -597,11 +598,6 @@ public:
                                         ertPhaseMask(uses),
                                         timer.currentPosixTime());
         }
-
-
-
-
-
     }
 
     void writeKeyword(const std::string& keywordName, const std::vector<double> &data)
@@ -1228,6 +1224,10 @@ void EclipseWriter::writeInit(const SimulatorTimerInterface &timer, const NNC& n
             for (NNCdata nd : nnc.nncdata()) {
                 tran.push_back(nd.trans);
             }
+            if (eclipseState_->getDeckUnitSystem().getType() == UnitSystem::UNIT_TYPE_METRIC)
+                EclipseWriterDetails::convertFromSiTo(tran, 1.0 / Opm::Metric::Transmissibility);
+            else
+                EclipseWriterDetails::convertFromSiTo(tran, 1.0 / Opm::Field::Transmissibility);
             fortio.writeKeyword("TRANNNC", tran);
         }
     }

--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -28,6 +28,7 @@
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
@@ -38,7 +39,6 @@
 #include <array>
 #include <memory>
 
-struct UnstructuredGrid;
 
 namespace Opm {
 
@@ -80,8 +80,11 @@ public:
 
     /**
      * Write the static eclipse data (grid, PVT curves, etc) to disk.
+     *
+     * If NNC is given, writes TRANNNC keyword.
      */
-    virtual void writeInit(const SimulatorTimerInterface &timer);
+     virtual void writeInit(const SimulatorTimerInterface &timer,
+                            const NNC& nnc = NNC());
 
     /*!
      * \brief Write a reservoir state and summary information to disk.


### PR DESCRIPTION
- Writer takes NNC argument
- Sets NNC info to ecl_self_add_nnc
- Writes TRANNNC to INIT
- Writes NNCHEAD, NNC1 and NNC2 to EGRID

Most importantly, `writeInit` takes an optional NNC argument and writes it to file if present.

See
- OPM/opm-simulators#680
- OPM/opm-parser#806
