### PR TITLE
Use UnitSystem::to/from_si over conversion_table

### DIFF
--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -55,13 +55,11 @@ class Summary {
         };
 
     private:
-
         ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > ecl_sum;
         std::map< const char*, std::vector< sum_node > > wvar;
         std::map< const char*, std::vector< sum_node > > gvar;
         const ecl_sum_tstep_type* prev_tstep = nullptr;
         double duration = 0;
-        const double* conversions;
 };
 
 }


### PR DESCRIPTION
Keep up with a change in opm-parser which moves this functionality into
UnitSystem.

Fixes the currently broken master.
