### PR TITLE
Fix compile and warning

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -481,7 +481,7 @@ class EclipseWriter::Impl {
 };
 
 EclipseWriter::Impl::Impl( std::shared_ptr< const EclipseState > eclipseState,
-                           int numCells,
+                           int numCellsArg,
                            const int* compressed_to_cart )
     : es( eclipseState )
     , outputDir( eclipseState->getIOConfig()->getOutputDir() )
@@ -490,9 +490,9 @@ EclipseWriter::Impl::Impl( std::shared_ptr< const EclipseState > eclipseState,
     , rft( outputDir.c_str(), baseName.c_str(),
            es->getIOConfig()->getFMTOUT(),
            compressed_to_cart,
-           numCells, es->getInputGrid()->getCartesianSize() )
+           numCellsArg, es->getInputGrid()->getCartesianSize() )
     , sim_start_time( es->getSchedule()->posixStartTime() )
-    , numCells( numCells )
+    , numCells( numCellsArg )
     , compressed_to_cartesian( compressed_to_cart )
     , gridToEclipseIdx( numCells, int(-1) )
     , output_enabled( eclipseState->getIOConfig()->getOutputEnabled() )

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -527,7 +527,7 @@ void EclipseWriter::writeInit( const NNC& nnc ) {
         auto data = props.getDoubleGridProperty("PERMX").getData();
         convertFromSiTo( data,
                          units,
-                         units.measure::permeability );
+                         UnitSystem::measure::permeability );
         restrictAndReorderToActiveCells(data, gridToEclipseIdx.size(), gridToEclipseIdx.data());
         fortio.writeKeyword("PERMX", data);
     }
@@ -535,7 +535,7 @@ void EclipseWriter::writeInit( const NNC& nnc ) {
         auto data = props.getDoubleGridProperty("PERMY").getData();
         convertFromSiTo( data,
                          units,
-                         units.measure::permeability );
+                         UnitSystem::measure::permeability );
         restrictAndReorderToActiveCells(data, gridToEclipseIdx.size(), gridToEclipseIdx.data());
         fortio.writeKeyword("PERMY", data);
     }
@@ -543,7 +543,7 @@ void EclipseWriter::writeInit( const NNC& nnc ) {
         auto data = props.getDoubleGridProperty("PERMZ").getData();
         convertFromSiTo( data,
                          units,
-                         units.measure::permeability );
+                         UnitSystem::measure::permeability );
         restrictAndReorderToActiveCells(data, gridToEclipseIdx.size(), gridToEclipseIdx.data());
         fortio.writeKeyword("PERMZ", data);
     }
@@ -555,7 +555,7 @@ void EclipseWriter::writeInit( const NNC& nnc ) {
         tran.push_back( nd.trans );
     }
 
-    convertFromSiTo( tran, units, units.measure::transmissibility );
+    convertFromSiTo( tran, units, UnitSystem::measure::transmissibility );
     fortio.writeKeyword("TRANNNC", tran);
 
 }
@@ -581,7 +581,7 @@ void EclipseWriter::writeTimeStep(int report_step,
     auto& pressure = cells[ dc::PRESSURE ];
     convertFromSiTo( pressure,
                      units,
-                     units.measure::pressure );
+                     UnitSystem::measure::pressure );
     restrictAndReorderToActiveCells(pressure, gridToEclipseIdx.size(), gridToEclipseIdx.data());
 
     if( cells.has( dc::SWAT ) ) {
@@ -598,7 +598,7 @@ void EclipseWriter::writeTimeStep(int report_step,
     IOConfigConstPtr ioConfig = this->impl->es->getIOConfigConst();
 
 
-    const auto days = units.from_si( units.measure::time, secs_elapsed );
+    const auto days = units.from_si( UnitSystem::measure::time, secs_elapsed );
     const auto& schedule = *es.getSchedule();
 
     // Write restart file
@@ -673,7 +673,7 @@ void EclipseWriter::writeTimeStep(int report_step,
         auto& temperature = cells[ dc::TEMP ];
         convertFromSiTo( temperature,
                          units,
-                         units.measure::temperature );
+                         UnitSystem::measure::temperature );
         sol.add( ERT::EclKW<float>("TEMP", temperature) );
 
 

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -318,7 +318,7 @@ inline double injevol( const Well& w,
     if( timestep == 0 ) return 0.0;
 
     const auto rate = injerate( w, timestep - 1, wt, units );
-    return rate * duration * units.from_si( units.measure::time, 1 );
+    return rate * duration * units.from_si( measure::time, 1 );
 }
 
 inline double get_rate( const data::Well& w,
@@ -483,10 +483,10 @@ inline double sum_vol( const std::vector< const data::Well* >& wells,
 
     switch( phase ) {
         case rt::wat: /* intentional fall-through */
-        case rt::oil: return units.from_si( units.measure::liquid_surface_volume,
+        case rt::oil: return units.from_si( measure::liquid_surface_volume,
                                             duration * sum( wells, phase ) );
 
-        case rt::gas: return units.from_si( units.measure::gas_surface_volume,
+        case rt::gas: return units.from_si( measure::gas_surface_volume,
                                             duration * sum( wells, phase ) );
         default: break;
     }

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -23,7 +23,9 @@
 #endif
 
 #define BOOST_TEST_MODULE EclipseWriter
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/output/eclipse/EclipseWriter.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>


### PR DESCRIPTION
The compile fix is due to the same problem as was addressed in #35.

The quoted part from the standard in that PR, which version of C++ does that apply to? Certainly my compiler does not like the member syntax there.
