### PR TITLE
Well shared_ptr alias deprecated

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -358,7 +358,7 @@ class RFT {
              size_t num_cells,
              size_t cartesian_size );
 
-        void writeTimeStep( std::vector< std::shared_ptr< const Well > >,
+        void writeTimeStep( std::vector< const Well* >,
                             const EclipseGrid& grid,
                             int report_step,
                             time_t current_time,
@@ -407,7 +407,7 @@ inline ert_ecl_unit_enum to_ert_unit( UnitSystem::UnitType t ) {
     throw std::invalid_argument("unhandled enum value");
 }
 
-void RFT::writeTimeStep( std::vector< std::shared_ptr< const Well > > wells,
+void RFT::writeTimeStep( std::vector< const Well* > wells,
                          const EclipseGrid& grid,
                          int report_step,
                          time_t current_time,
@@ -604,9 +604,9 @@ void EclipseWriter::writeTimeStep(int report_step,
     // Write restart file
     if(!isSubstep && ioConfig->getWriteRestartFile(report_step))
     {
-        const size_t ncwmax                 = schedule.getMaxNumCompletionsForWells(report_step);
-        const size_t numWells               = schedule.numWells(report_step);
-        std::vector<WellConstPtr> wells_ptr = schedule.getWells(report_step);
+        const size_t ncwmax     = schedule.getMaxNumCompletionsForWells(report_step);
+        const size_t numWells   = schedule.numWells(report_step);
+        auto wells_ptr          = schedule.getWells(report_step);
 
         std::vector<const char*> zwell_data( numWells * Restart::NZWELZ , "");
         std::vector<int>         iwell_data( numWells * Restart::NIWELZ , 0 );

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -670,7 +670,7 @@ void Summary::add_timestep( int report_step,
     for( const auto& pair : this->wvar ) {
         const auto* wname = pair.first;
 
-        const auto& state_well = es.getSchedule()->getWell( wname );
+        const auto& state_well = *es.getSchedule()->getWell( wname );
         const auto& sim_well = wells.wells.find( wname ) != wells.wells.end()
                              ? wells.at( wname )
                              : dummy_well;

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -57,13 +57,13 @@ void verifyWellState(const std::string& rst_filename,
   int numwells = well_info_get_num_wells(well_info);
   BOOST_CHECK_EQUAL( numwells, schedule->numWells() );
 
-  std::vector<Opm::WellConstPtr> wells = schedule->getWells();
+  auto wells = schedule->getWells();
 
   for (int i = 0; i < numwells; ++i) {
 
     //Verify wellnames
     const char * wellname = well_info_iget_well_name(well_info, i);
-    auto well = wells.at(i);
+    auto* well = wells.at(i);
     BOOST_CHECK_EQUAL( wellname, well->name() );
 
     // Verify well-head position data


### PR DESCRIPTION
The shared_ptr aliasing is deprecated, and in the Well case this has
been removed upstream.

Upstream: https://github.com/OPM/opm-parser/pull/849
