### PR TITLE
Copy and save a Grid copy in Writer; apply actnum

### DIFF
--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -48,14 +48,15 @@ public:
      */
     EclipseWriter(std::shared_ptr< const EclipseState >,
                   int numCells,
-                  const int* compressedToCartesianCellIdx);
+                  const int* compressedToCartesianCellIdx,
+                  const NNC& );
 
     /**
      * Write the static eclipse data (grid, PVT curves, etc) to disk.
      *
-     * If NNC is given, writes TRANNNC keyword.
+     * If NNC is given to the constructor, writes TRANNNC keyword.
      */
-    void writeInit( const NNC& nnc );
+    void writeInit();
 
     /*!
      * \brief Write a reservoir state and summary information to disk.

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -262,11 +262,11 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
     auto& eclGrid = *es->getInputGrid();
 
     {
-        EclipseWriter eclWriter( es, 3 * 3 * 3, nullptr );
+        EclipseWriter eclWriter( es, 3 * 3 * 3, nullptr, NNC());
 
         auto start_time = util_make_datetime( 0, 0, 0, 10, 10, 2008 );
         auto first_step = util_make_datetime( 0, 0, 0, 10, 11, 2008 );
-        eclWriter.writeInit( NNC() );
+        eclWriter.writeInit();
 
         data::Wells wells;
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -121,11 +121,11 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
             * eclipseState->getInputGrid()->getNY()
             * eclipseState->getInputGrid()->getNZ();
 
-        EclipseWriter eclipseWriter( eclipseState, numCells, nullptr );
+        EclipseWriter eclipseWriter( eclipseState, numCells, nullptr, NNC() );
         time_t start_time = eclipseState->getSchedule()->posixStartTime();
         /* step time read from deck and hard-coded here */
         time_t step_time = util_make_datetime( 0, 0, 0, 10, 10, 2008 );
-        eclipseWriter.writeInit( NNC() );
+        eclipseWriter.writeInit();
 
         Opm::data::Wells wells {
             { { "OP_1", { {}, 1.0, 1.1, {} } },

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -229,10 +229,10 @@ first_sim(test_work_area_type * test_area) {
     const auto& grid = *eclipseState->getInputGrid();
     auto num_cells = grid.getNX() * grid.getNY() * grid.getNZ();
 
-    EclipseWriter eclWriter( eclipseState, num_cells, nullptr );
+    EclipseWriter eclWriter( eclipseState, num_cells, nullptr, NNC() );
     auto start_time = util_make_datetime( 0, 0, 0, 1, 11, 1979 );
     auto first_step = util_make_datetime( 0, 0, 0, 10, 10, 2008 );
-    eclWriter.writeInit( NNC() );
+    eclWriter.writeInit();
 
     auto sol = mkSolution( num_cells );
     auto wells = mkWells();

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -141,9 +141,9 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     auto es = Parser::parse( eclipse_data_filename, ParseContext() );
     auto eclipseState = std::make_shared< EclipseState >( es );
     const auto num_cells = eclipseState->getInputGrid()->getCartesianSize();
-    EclipseWriter eclipseWriter( eclipseState, num_cells, nullptr );
+    EclipseWriter eclipseWriter( eclipseState, num_cells, nullptr, NNC() );
 
-    eclipseWriter.writeInit( NNC() );
+    eclipseWriter.writeInit();
 
     int countTimeStep = eclipseState->getSchedule()->getTimeMap()->numTimesteps();
 


### PR DESCRIPTION
Simulators might modify the grid post EclipseState creation, so the Grid
fetched from there is unreliable. Copy the Deck-provided grid and apply
the manipulations at EclipseWriter construction time to ensure it uses
the same dimensions and has the same properties as the simulator.
