### PR TITLE
Summary output dir

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -606,7 +606,7 @@ inline double group_keywords( E keyword,
 namespace out {
 
 Summary::Summary( const EclipseState& st, const SummaryConfig& sum ) :
-    Summary( st, sum, st.getIOConfig()->getBaseName().c_str() )
+    Summary( st, sum, st.getIOConfig()->fullBasePath().c_str() )
 {}
 
 Summary::Summary( const EclipseState& st,

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -123,6 +123,11 @@ struct setup {
 BOOST_AUTO_TEST_CASE(well_keywords) {
     setup cfg( "test_Summary_well" );
 
+    // Force to run in a directory, to make sure the basename with
+    // leading path works.
+    util_make_path( "PATH" );
+    cfg.name = "PATH/CASE";
+
     out::Summary writer( cfg.es, cfg.config, cfg.name );
     writer.add_timestep( 0, 0 * day, cfg.es, cfg.wells );
     writer.add_timestep( 1, 1 * day, cfg.es, cfg.wells );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -30,6 +30,8 @@
 #include <stdexcept>
 
 #include <ert/ecl/ecl_sum.h>
+#include <ert/util/util.h>
+#include <ert/util/TestArea.hpp>
 
 #include <opm/output/Wells.hpp>
 #include <opm/output/eclipse/Summary.hpp>
@@ -101,19 +103,17 @@ struct setup {
     SummaryConfig config;
     data::Wells wells;
     std::string name;
+    ERT::TestArea ta;
 
     setup( const std::string& fname ) :
         deck( Parser().parseFile( path, ParseContext() ) ),
         es( deck, ParseContext() ),
         config( *deck, es ),
         wells( result_wells() ),
-        name( fname )
-    {}
+        name( fname ),
+        ta( ERT::TestArea("test_summary") )
+    { }
 
-    ~setup() {
-        std::remove( ( name + ".UNSMRY" ).c_str() );
-        std::remove( ( name + ".SMSPEC" ).c_str() );
-    }
 };
 
 /*


### PR DESCRIPTION
The summary writer will ask the IOConfig object for a basename with a prepended output path.

Depends on: https://github.com/OPM/opm-parser/pull/858
