### PR TITLE
New private Summary implementation

### DIFF
--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -21,16 +21,16 @@
 #define OPM_OUTPUT_SUMMARY_HPP
 
 #include <string>
-#include <vector>
 
 #include <ert/ecl/ecl_sum.h>
-#include <ert/util/ert_unique_ptr.hpp>
+#include <ert/ecl/Smspec.hpp>
 
 #include <opm/output/Wells.hpp>
 
 namespace Opm {
 
     class EclipseState;
+    class Schedule;
     class SummaryConfig;
 
 namespace out {
@@ -45,19 +45,13 @@ class Summary {
                            const EclipseState&, const data::Wells& );
         void write();
 
-        using kwtype = uint32_t;
-        struct sum_node {
-            sum_node( kwtype k, smspec_node_type* n ) :
-                kw( k ), node( n ) {}
-
-            kwtype kw;
-            smspec_node_type* node;
-        };
+        ~Summary();
 
     private:
+        class keyword_handlers;
+
         ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > ecl_sum;
-        std::map< const char*, std::vector< sum_node > > wvar;
-        std::map< const char*, std::vector< sum_node > > gvar;
+        std::unique_ptr< keyword_handlers > handlers;
         const ecl_sum_tstep_type* prev_tstep = nullptr;
         double prev_time_elapsed = 0;
 };

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -197,9 +197,9 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( 0,    ecl_sum_get_well_var( resp, 1, "W_3", "WGIRH" ), 1e-5 );
 
     /* Injection totals (history) */
-    BOOST_CHECK_CLOSE( 0,    ecl_sum_get_well_var( resp, 1, "W_3", "WWITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_well_var( resp, 1, "W_3", "WWITH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 0,    ecl_sum_get_well_var( resp, 1, "W_3", "WGITH" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_well_var( resp, 2, "W_3", "WWITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 60.0, ecl_sum_get_well_var( resp, 2, "W_3", "WWITH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 0,    ecl_sum_get_well_var( resp, 2, "W_3", "WGITH" ), 1e-5 );
 
     /* WWCT - water cut */
@@ -302,9 +302,9 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 2 * 30.2, ecl_sum_get_group_var( resp, 2, "G_2", "GGIT" ), 1e-5 );
 
     /* Injection totals (history) */
-    BOOST_CHECK_CLOSE( 0,    ecl_sum_get_group_var( resp, 1, "G_2", "GWITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWITH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 0,    ecl_sum_get_group_var( resp, 1, "G_2", "GGITH" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 2, "G_2", "GWITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 60.0, ecl_sum_get_group_var( resp, 2, "G_2", "GWITH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 0,    ecl_sum_get_group_var( resp, 2, "G_2", "GGITH" ), 1e-5 );
 
     /* gwct - water cut */
@@ -340,4 +340,21 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     BOOST_CHECK_EQUAL( ecl_sum_iget_sim_days( resp, 1 ), 5 );
     BOOST_CHECK_EQUAL( ecl_sum_iget_sim_days( resp, 2 ), 10 );
     BOOST_CHECK_EQUAL( ecl_sum_get_sim_length( resp ), 10 );
+}
+
+BOOST_AUTO_TEST_CASE(skip_unknown_var) {
+    setup cfg( "test_Summary_skip_unknown_var" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 1, 2 *  day, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 5 *  day, cfg.es, cfg.wells );
+    writer.add_timestep( 2, 10 * day, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    /* verify that some non-supported keywords aren't written to the file */
+    BOOST_CHECK( !ecl_sum_has_well_var( resp, "W_1", "WPI" ) );
+    BOOST_CHECK( !ecl_sum_has_field_var( resp, "FVIR" ) );
 }


### PR DESCRIPTION
A rewritten Summary.cpp with some minor header modifications. Synposis
of the new implementation:
- Uses `unordered_map< string, std::function >` for dispatch, instead of
  multiple functions and a switch
- Some poor man's function composition support has been added
  (privately) to avoid a lot of reptition in the post processing.
- Functions assume they work over lists of wells instead of single wells
  being special cased - this means groups of well etc. can share
  implementation with single wells and field keywords.
- Unsupported keywords are not written in the Summary file.

Furthermore, some comments on special cases and overall approach and
a generally more declarative implementation. This change is invisible to
downstream developers. Users will obviously see no more garbage
keywords.
