### PR TITLE
Completion production/injection rates/totals; Field keywords

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -369,6 +369,58 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "CWPT", liq_vol( prodcrate< rt::wat > ) },
     { "COPT", liq_vol( prodcrate< rt::oil > ) },
     { "CGPT", gas_vol( prodcrate< rt::gas > ) },
+
+    { "FWPR", prodrate< rt::wat > },
+    { "FOPR", prodrate< rt::oil > },
+    { "FGPR", prodrate< rt::gas > },
+    { "FLPR", sum( prodrate< rt::wat >, prodrate< rt::oil > ) },
+    { "FWPT", liq_vol( prodrate< rt::wat > ) },
+    { "FOPT", liq_vol( prodrate< rt::oil > ) },
+    { "FGPT", gas_vol( prodrate< rt::gas > ) },
+    { "FLPT", liq_vol( sum( prodrate< rt::wat >,
+                            prodrate< rt::oil > ) ) },
+
+    { "FWIR", injerate< rt::wat > },
+    { "FOIR", injerate< rt::oil > },
+    { "FGIR", injerate< rt::gas > },
+    { "FLIR", sum( injerate< rt::wat >, injerate< rt::oil > ) },
+    { "FWIT", liq_vol( injerate< rt::wat > ) },
+    { "FOIT", liq_vol( injerate< rt::oil > ) },
+    { "FGIT", gas_vol( injerate< rt::gas > ) },
+    { "FLIT", liq_vol( sum( injerate< rt::wat >,
+                            injerate< rt::oil > ) ) },
+
+    { "FWPRH", production_history< Phase::WATER > },
+    { "FOPRH", production_history< Phase::OIL > },
+    { "FGPRH", production_history< Phase::GAS > },
+    { "FLPRH", sum( production_history< Phase::WATER >,
+                    production_history< Phase::OIL > ) },
+    { "FWPTH", liq_vol( production_history< Phase::WATER > ) },
+    { "FOPTH", liq_vol( production_history< Phase::OIL > ) },
+    { "FGPTH", gas_vol( production_history< Phase::GAS > ) },
+    { "FLPTH", liq_vol( sum( production_history< Phase::WATER >,
+                             production_history< Phase::OIL > ) ) },
+
+    { "FWIRH", injection_history< Phase::WATER > },
+    { "FOIRH", injection_history< Phase::OIL > },
+    { "FGIRH", injection_history< Phase::GAS > },
+    { "FWITH", liq_vol( injection_history< Phase::WATER > ) },
+    { "FOITH", liq_vol( injection_history< Phase::OIL > ) },
+    { "FGITH", gas_vol( injection_history< Phase::GAS > ) },
+
+    { "FWCT", div( prodrate< rt::wat >,
+                   sum( prodrate< rt::wat >, prodrate< rt::oil > ) ) },
+    { "FWCT", div( prodrate< rt::wat >,
+                   sum( prodrate< rt::wat >, prodrate< rt::oil > ) ) },
+    { "FGOR", div( prodrate< rt::gas >, prodrate< rt::oil > ) },
+    { "FGOR", div( prodrate< rt::gas >, prodrate< rt::oil > ) },
+    { "FGLR", div( prodrate< rt::gas >,
+                   sum( prodrate< rt::wat >, prodrate< rt::oil > ) ) },
+    { "FGORH", div( production_history< Phase::GAS >,
+                    production_history< Phase::OIL > ) },
+    { "FGLRH", div( production_history< Phase::GAS >,
+                    sum( production_history< Phase::WATER >,
+                         production_history< Phase::OIL > ) ) },
 };
 
 inline std::vector< const Well* > find_wells( const Schedule& schedule,
@@ -394,6 +446,9 @@ inline std::vector< const Well* > find_wells( const Schedule& schedule,
 
         return wells;
     }
+
+    if( type == ECL_SMSPEC_FIELD_VAR )
+        return schedule.getWells();
 
     return {};
 }

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -278,6 +278,8 @@ CGIT
 /
 
 -- Production per connection
+-- Using all the different ways of specifying connections here
+-- as an informal test that we still get the data we want
 CWPR
  'W_1' 1 1 1 /
 /
@@ -321,6 +323,8 @@ WELSPECS
 
 -- Completion data.
 COMPDAT
+-- 'Well' I J K1 K2
+-- Passing 0 to I/J means they'll get the well head I/J
     W_1 0 0 1 1 /
     W_2 0 0 1 1 /
     W_2 1 1 1 1 /

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -258,31 +258,51 @@ WBP
 /
 WBP4
 /
+
 -- Water injection per connection
-----CWIR
-----'F-1H' /
-----'F-2H' /
-----'F-3H' /
-----'F-4H' /
-----'C-1H' /
-----'C-2H' /
-----'C-3H' /
-----'C-4H' /
-----/
-----CWIT
-----'F-1H' /
-----'F-2H' /
-----'F-3H' /
-----'F-4H' /
-----'C-1H' /
-----'C-2H' /
-----'C-3H' /
-----'C-4H' /
-----/
+CWIR
+'W_3' /
+/
+
+-- Gas injection on 3 1 1 (45)
+CGIR
+'W_3' 3 1 1 /
+/
+
+CWIT
+'W_3' /
+/
+
+CGIT
+* /
+/
+
+-- Production per connection
+CWPR
+ 'W_1' 1 1 1 /
+/
+
+COPR
+ 'W_1' /
+/
+
+CGPR
+ '*' /
+/
+
+CWPT
+ 'W_1' 1 1 1 /
+/
+
+COPT
+ 'W_1' /
+/
+
+CGPT
+ '*' 1 1 1 /
+/
+
 ---- Connection production rates
-----CGPT
-----'E-4AH' /
-----/
 ----CGFR
 ----'E-4AH' /
 ----/
@@ -294,9 +314,17 @@ SCHEDULE
 
 -- Three wells, two producers (so that we can form a group) and one injector
 WELSPECS
-     'W_1'        'G_1'   30   37  3.33       'OIL'  7* /
-     'W_2'        'G_1'   30   37  3.33       'OIL'  7* /
-     'W_3'        'G_2'   20   51  3.92       'WATER'  7* /
+     'W_1'        'G_1'   1    1  3.33       'OIL'  7* /
+     'W_2'        'G_1'   2    1  3.33       'OIL'  7* /
+     'W_3'        'G_2'   3    1  3.92       'WATER'  7* /
+/
+
+-- Completion data.
+COMPDAT
+    W_1 0 0 1 1 /
+    W_2 0 0 1 1 /
+    W_2 1 1 1 1 /
+    W_3 0 0 1 1 /
 /
 
 WCONHIST

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -380,6 +380,82 @@ BOOST_AUTO_TEST_CASE(completion_kewords) {
     BOOST_CHECK_CLOSE( 2 * 200.2, ecl_sum_get_well_completion_var( resp, 2, "W_2", "CGPT", 1 ), 1e-5 );
 }
 
+BOOST_AUTO_TEST_CASE(field_keywords) {
+    setup cfg( "test_Summary_field" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 0, 0 * day, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 1 * day, cfg.es, cfg.wells );
+    writer.add_timestep( 2, 2 * day, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    /* Production rates */
+    BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_field_var( resp, 1, "FWPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.1 + 20.1, ecl_sum_get_field_var( resp, 1, "FOPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.2 + 20.2, ecl_sum_get_field_var( resp, 1, "FGPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.0 + 20.0 + 10.1 + 20.1,
+                                    ecl_sum_get_field_var( resp, 1, "FLPR" ), 1e-5 );
+
+    /* Production totals */
+    BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_field_var( resp, 1, "FWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.1 + 20.1, ecl_sum_get_field_var( resp, 1, "FOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.2 + 20.2, ecl_sum_get_field_var( resp, 1, "FGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.0 + 20.0 + 10.1 + 20.1,
+                                    ecl_sum_get_field_var( resp, 1, "FLPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.0 + 20.0), ecl_sum_get_field_var( resp, 2, "FWPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.1 + 20.1), ecl_sum_get_field_var( resp, 2, "FOPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.2 + 20.2), ecl_sum_get_field_var( resp, 2, "FGPT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.0 + 20.0 + 10.1 + 20.1),
+                                    ecl_sum_get_field_var( resp, 2, "FLPT" ), 1e-5 );
+
+    /* Production rates (history) */
+    BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_field_var( resp, 1, "FWPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.1 + 20.1, ecl_sum_get_field_var( resp, 1, "FOPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.2 + 20.2, ecl_sum_get_field_var( resp, 1, "FGPRH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.0 + 10.1 + 20.0 + 20.1,
+                                    ecl_sum_get_field_var( resp, 1, "FLPRH" ), 1e-5 );
+
+    /* Production totals (history) */
+    BOOST_CHECK_CLOSE( (10.0 + 20.0), ecl_sum_get_field_var( resp, 1, "FWPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (10.1 + 20.1), ecl_sum_get_field_var( resp, 1, "FOPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (10.2 + 20.2), ecl_sum_get_field_var( resp, 1, "FGPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( (10.0 + 20.0 + 10.1 + 20.1),
+                                      ecl_sum_get_field_var( resp, 1, "FLPTH" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 2 * (10.0 + 20.0), ecl_sum_get_field_var( resp, 2, "FWPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.1 + 20.1), ecl_sum_get_field_var( resp, 2, "FOPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.2 + 20.2), ecl_sum_get_field_var( resp, 2, "FGPTH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (10.0 + 20.0 + 10.1 + 20.1),
+                                          ecl_sum_get_field_var( resp, 2, "FLPTH" ), 1e-5 );
+
+    /* Injection rates */
+    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_field_var( resp, 1, "FWIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_field_var( resp, 1, "FGIR" ), 1e-5 );
+
+    /* Injection totals */
+    BOOST_CHECK_CLOSE( 30.0,     ecl_sum_get_field_var( resp, 1, "FWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2,     ecl_sum_get_field_var( resp, 1, "FGIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 30.0, ecl_sum_get_field_var( resp, 2, "FWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 30.2, ecl_sum_get_field_var( resp, 2, "FGIT" ), 1e-5 );
+
+    /* Injection totals (history) */
+    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_field_var( resp, 1, "FWITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 60.0, ecl_sum_get_field_var( resp, 2, "FWITH" ), 1e-5 );
+
+    /* gwct - water cut */
+    const double wcut = (10.0 + 20.0) / ( 10.0 + 10.1 + 20.0 + 20.1 );
+    BOOST_CHECK_CLOSE( wcut, ecl_sum_get_field_var( resp, 1, "FWCT" ), 1e-5 );
+
+    /* ggor - gas-oil ratio */
+    const double ggor = (10.2 + 20.2) / (10.1 + 20.1);
+    BOOST_CHECK_CLOSE( ggor, ecl_sum_get_field_var( resp, 1, "FGOR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( ggor, ecl_sum_get_field_var( resp, 1, "FGORH" ), 1e-5 );
+
+}
+
 BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_Summary_report_steps_time" );
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -84,9 +84,29 @@ static data::Wells result_wells() {
     rates3.set( rt::oil, 30.1 / day );
     rates3.set( rt::gas, 30.2 / day );
 
-    data::Well well1 { rates1, 0.1 * ps, 0.2 * ps, {} };
-    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, {} };
-    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, {} };
+    /* completion rates */
+    data::Rates crates1;
+    crates1.set( rt::wat, -100.0 / day );
+    crates1.set( rt::oil, -100.1 / day );
+    crates1.set( rt::gas, -100.2 / day );
+
+    data::Rates crates2;
+    crates2.set( rt::wat, -200.0 / day );
+    crates2.set( rt::oil, -200.1 / day );
+    crates2.set( rt::gas, -200.2 / day );
+
+    data::Rates crates3;
+    crates3.set( rt::wat, 300.0 / day );
+    crates3.set( rt::oil, 300.1 / day );
+    crates3.set( rt::gas, 300.2 / day );
+
+    data::Completion comp1 { 1, crates1 };
+    data::Completion comp2 { 1, crates2 };
+    data::Completion comp3 { 3, crates3 };
+
+    data::Well well1 { rates1, 0.1 * ps, 0.2 * ps, { {1, comp1} } };
+    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, { {1, comp2} } };
+    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, { {3, comp3} } };
 
     return { { "W_1", well1 }, { "W_2", well2 }, { "W_3", well3 } };
 }
@@ -318,6 +338,46 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     const double ggor2 = 30.2 / 30.1;
     BOOST_CHECK_CLOSE( ggor1, ecl_sum_get_group_var( resp, 1, "G_1", "GGOR" ), 1e-5 );
     BOOST_CHECK_CLOSE( ggor2, ecl_sum_get_group_var( resp, 1, "G_2", "GGOR" ), 1e-5 );
+}
+
+BOOST_AUTO_TEST_CASE(completion_kewords) {
+    setup cfg( "test_Summary_completion" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.name );
+    writer.add_timestep( 0, 0 * day, cfg.es, cfg.wells );
+    writer.add_timestep( 1, 1 * day, cfg.es, cfg.wells );
+    writer.add_timestep( 2, 2 * day, cfg.es, cfg.wells );
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    /* Production rates */
+    BOOST_CHECK_CLOSE( 100.0,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "CWPR", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 100.1,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "COPR", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 100.2,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "CGPR", 1 ), 1e-5 );
+
+    /* Production totals */
+    BOOST_CHECK_CLOSE( 100.0,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "CWPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 100.1,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "COPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 100.2,     ecl_sum_get_well_completion_var( resp, 1, "W_1", "CGPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 100.0, ecl_sum_get_well_completion_var( resp, 2, "W_1", "CWPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 100.1, ecl_sum_get_well_completion_var( resp, 2, "W_1", "COPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 100.2, ecl_sum_get_well_completion_var( resp, 2, "W_1", "CGPT", 1 ), 1e-5 );
+
+    /* Injection rates */
+    BOOST_CHECK_CLOSE( 300.0,     ecl_sum_get_well_completion_var( resp, 1, "W_3", "CWIR", 3 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 300.2,     ecl_sum_get_well_completion_var( resp, 1, "W_3", "CGIR", 3 ), 1e-5 );
+
+    /* Injection totals */
+    BOOST_CHECK_CLOSE( 300.0,     ecl_sum_get_well_completion_var( resp, 1, "W_3", "CWIT", 3 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 300.2,     ecl_sum_get_well_completion_var( resp, 1, "W_3", "CGIT", 3 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 300.0, ecl_sum_get_well_completion_var( resp, 2, "W_3", "CWIT", 3 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 300.2, ecl_sum_get_well_completion_var( resp, 2, "W_3", "CGIT", 3 ), 1e-5 );
+
+    /* CGPT's wildcarding means W_2's completions should also be available */
+    BOOST_CHECK_CLOSE( 200.2,     ecl_sum_get_well_completion_var( resp, 1, "W_2", "CGPT", 1 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * 200.2, ecl_sum_get_well_completion_var( resp, 2, "W_2", "CGPT", 1 ), 1e-5 );
 }
 
 BOOST_AUTO_TEST_CASE(report_steps_time) {

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     /* WWCT - water cut */
     const double wwcut1 = 10.0 / ( 10.0 + 10.1 );
     const double wwcut2 = 20.0 / ( 20.0 + 20.1 );
-    const double wwcut3 = 30.0 / ( 30.0 + 30.1 );
+    const double wwcut3 = 0;
 
     BOOST_CHECK_CLOSE( wwcut1, ecl_sum_get_well_var( resp, 1, "W_1", "WWCT" ), 1e-5 );
     BOOST_CHECK_CLOSE( wwcut2, ecl_sum_get_well_var( resp, 1, "W_2", "WWCT" ), 1e-5 );
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     /* gas-oil ratio */
     const double wgor1 = 10.2 / 10.1;
     const double wgor2 = 20.2 / 20.1;
-    const double wgor3 = 30.2 / 30.1;
+    const double wgor3 = 0;
 
     BOOST_CHECK_CLOSE( wgor1, ecl_sum_get_well_var( resp, 1, "W_1", "WGOR" ), 1e-5 );
     BOOST_CHECK_CLOSE( wgor2, ecl_sum_get_well_var( resp, 1, "W_2", "WGOR" ), 1e-5 );
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     /* WGLR - gas-liquid rate */
     const double wglr1 = 10.2 / ( 10.0 + 10.1 );
     const double wglr2 = 20.2 / ( 20.0 + 20.1 );
-    const double wglr3 = 30.2 / ( 30.0 + 30.1 );
+    const double wglr3 = 0;
 
     BOOST_CHECK_CLOSE( wglr1, ecl_sum_get_well_var( resp, 1, "W_1", "WGLR" ), 1e-5 );
     BOOST_CHECK_CLOSE( wglr2, ecl_sum_get_well_var( resp, 1, "W_2", "WGLR" ), 1e-5 );
@@ -329,13 +329,13 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
 
     /* gwct - water cut */
     const double gwcut1 = (10.0 + 20.0) / ( 10.0 + 10.1 + 20.0 + 20.1 );
-    const double gwcut2 = 30.0 / ( 30.0 + 30.1 );
+    const double gwcut2 = 0;
     BOOST_CHECK_CLOSE( gwcut1, ecl_sum_get_group_var( resp, 1, "G_1", "GWCT" ), 1e-5 );
     BOOST_CHECK_CLOSE( gwcut2, ecl_sum_get_group_var( resp, 1, "G_2", "GWCT" ), 1e-5 );
 
     /* ggor - gas-oil ratio */
     const double ggor1 = (10.2 + 20.2) / (10.1 + 20.1);
-    const double ggor2 = 30.2 / 30.1;
+    const double ggor2 = 0;
     BOOST_CHECK_CLOSE( ggor1, ecl_sum_get_group_var( resp, 1, "G_1", "GGOR" ), 1e-5 );
     BOOST_CHECK_CLOSE( ggor2, ecl_sum_get_group_var( resp, 1, "G_2", "GGOR" ), 1e-5 );
 }


### PR DESCRIPTION
A small set of the completion family of keywords, water/oil/gas
production and injection. The tests and example data file are updated
accordingly, with edge cases.

Requires https://github.com/Ensembles/ert/pull/1167 and https://github.com/OPM/opm-parser/pull/881 (bugfixes). 

note: I've added support for a set of Field keywords to this PR. Easily split up obviously, but they're along the same lines so I figured  it's fine.
