### PR TITLE
Add missing include directives.

### DIFF
--- a/opm/test_util/EclFilesComparator.cpp
+++ b/opm/test_util/EclFilesComparator.cpp
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_grid.h>
+#include <cmath>
+#include <numeric>
 
 bool ECLFilesComparator::keywordValidForComparing(const std::string& keyword) const {
     auto it = std::find(keywords1.begin(), keywords1.end(), keyword);

--- a/opm/test_util/summaryComparator.cpp
+++ b/opm/test_util/summaryComparator.cpp
@@ -22,6 +22,8 @@
 #include <ert/util/int_vector.h>
 #include <ert/util/bool_vector.h>
 #include <opm/common/ErrorMacros.hpp>
+#include <cmath>
+#include <numeric>
 
 SummaryComparator::SummaryComparator(const char* basename1, const char* basename2, double absoluteTolerance, double relativeTolerance){
     ecl_sum1 = ecl_sum_fread_alloc_case(basename1, ":");


### PR DESCRIPTION
These are required for std::accumulate (numeric) and std::abs (cmath).

I am still very much against the use of std::abs in anything but extremely generic code (where you need a template code to work with both floating point and integers). Apparently on the original developer's platform cmath was included via other includes, while that did not happen on my platform. So I got compile errors like this:

```
/Users/atgeirr/opm-build-debug/opm-output/opm/test_util/EclFilesComparator.cpp:267:12: error: call to 'abs' is ambiguous
    val1 = std::abs(val1);
           ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstdlib:159:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstdlib:161:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
```

Note that all these three overloads the compiler tries (but fails, thus the error) to choose between are for integer types. If for some reason my platform had not provided those extra overloads, the compiler would silently have chosen the int overload, even for double arguments. I have said before that I find the C++ treatment of abs() horrible, and think we should use std::fabs() instead whenever we know the argument is a floating point number.

In this PR I have not made that change, since it is not required to restore correct compilation, but I'll provide a PR to that effect if the maintainer agrees it should be changed.
