### PR TITLE
InitConfig is now reference

### DIFF
--- a/opm/output/eclipse/EclipseReader.cpp
+++ b/opm/output/eclipse/EclipseReader.cpp
@@ -133,10 +133,10 @@ namespace {
 std::pair< data::Solution, data::Wells >
 init_from_restart_file( const EclipseState& es, int numcells ) {
 
-    InitConfigConstPtr initConfig        = es.getInitConfig();
+    const InitConfig& initConfig         = es.getInitConfig();
     IOConfigConstPtr ioConfig            = es.getIOConfig();
-    int restart_step                     = initConfig->getRestartStep();
-    const std::string& restart_file_root = initConfig->getRestartRootName();
+    int restart_step                     = initConfig.getRestartStep();
+    const std::string& restart_file_root = initConfig.getRestartRootName();
     bool output                          = false;
     const std::string filename           = ioConfig->getRestartFileName(
                                                         restart_file_root,

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -127,7 +127,7 @@ struct setup {
 
     setup( const std::string& fname , const ParseContext& parseContext = ParseContext( )) :
         deck( Parser().parseFile( path, parseContext ) ),
-        es( deck, ParseContext() ),
+        es( *deck, ParseContext() ),
         config( *deck, es , parseContext ),
         wells( result_wells() ),
         name( fname ),


### PR DESCRIPTION
Two minor changes:
- InitConfig in opm-parser:EclipseConfig is now returned as a reference, not shared_ptr.
- Use the correct EclipseState constructor.

Downstream of OPM/opm-parser#890.
