### PR TITLE
Restart: write properties

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -640,6 +640,7 @@ void EclipseWriter::writeTimeStep(int report_step,
                                   double secs_elapsed,
                                   data::Solution cells,
                                   data::Wells wells,
+                                  const std::vector<data::CellData>& simProps,
                                   bool  write_float)
 {
 
@@ -759,6 +760,23 @@ void EclipseWriter::writeTimeStep(int report_step,
                 sol.addFromCells<float>( cells );
             else
                 sol.addFromCells<double>( cells );
+            {
+                const auto& compressedToCartesian = this->impl->compressedToCartesian;
+                for (const auto& prop : simProps) {
+                    const auto& opm_data = prop.data;
+                    auto ecl_data = restrictAndReorderToActiveCells( opm_data,
+                                                                     compressedToCartesian.size(),
+                                                                     compressedToCartesian.data());
+                    convertFromSiTo( ecl_data,
+                                     units,
+                                     prop.dim );
+
+                    if (write_float)
+                        sol.add( ERT::EclKW<float>(prop.name , ecl_data));
+                    else
+                        sol.add( ERT::EclKW<double>(prop.name , ecl_data));
+                }
+            }
         }
     }
 

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -636,10 +636,10 @@ void EclipseWriter::writeInitAndEgrid(const std::vector<data::CellData>& simProp
 
 // implementation of the writeTimeStep method
 void EclipseWriter::writeTimeStep(int report_step,
+                                  bool  isSubstep,
                                   double secs_elapsed,
                                   data::Solution cells,
                                   data::Wells wells,
-                                  bool  isSubstep,
                                   bool  write_float)
 {
 

--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -74,10 +74,10 @@ public:
      * meaningful after the first time step has been completed.
      */
     void writeTimeStep( int report_step,
+                        bool isSubstep,
                         double seconds_elapsed,
                         data::Solution,
                         data::Wells,
-                        bool isSubstep,
                         bool write_float = true);
 
     EclipseWriter( const EclipseWriter& ) = delete;

--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -72,12 +72,27 @@ public:
      * The summary information can then be visualized using tools from
      * ERT or ECLIPSE. Note that calling this method is only
      * meaningful after the first time step has been completed.
+     *
+     * The optional simProps vector contains fields which have been
+     * calculated by the simulator and are written to the restart
+     * file. Examples of such fields would be the relative
+     * permeabilities KRO, KRW and KRG and fluxes. The keywords which
+     * can be added here are represented with mnenonics in the RPTRST
+     * keyword.
+     *
+     * By default the various solution fields like PRESSURE and
+     * SWAT/SGAS should be written in single precision (i.e. as
+     * float). That is what eclipse does, and probably what most third
+     * party application expect - however passing false for the
+     * optional variable write_float the solution fields will be
+     * written in double precision.
      */
     void writeTimeStep( int report_step,
                         bool isSubstep,
                         double seconds_elapsed,
                         data::Solution,
                         data::Wells,
+                        const std::vector<data::CellData>& simProps = {},
                         bool write_float = true);
 
     EclipseWriter( const EclipseWriter& ) = delete;

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -290,9 +290,10 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
 
         for( int i = 0; i < 5; ++i ) {
             eclWriter.writeTimeStep( i,
+                                     false,
                                      first_step - start_time,
                                      createBlackoilState( i, 3 * 3 * 3 ),
-                                     wells, false);
+                                     wells);
 
             checkRestartFile( i );
 

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -215,6 +215,12 @@ void checkRestartFile( int timeStepIdx ) {
                 const auto resultData = getErtData< float >( eclKeyword );
                 compareErtData( sol[ ds::SGAS ], resultData, 1e-4 );
             }
+
+            if (keywordName == "KRO")
+                BOOST_CHECK_EQUAL( 1.0 * i * ecl_kw_get_size( eclKeyword ) , ecl_kw_element_sum_float( eclKeyword ));
+
+            if (keywordName == "KRG")
+                BOOST_CHECK_EQUAL( 10.0 * i * ecl_kw_get_size( eclKeyword ) , ecl_kw_element_sum_float( eclKeyword ));
         }
 
         fortio_fclose(rstFile);
@@ -289,11 +295,15 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
         data::Wells wells;
 
         for( int i = 0; i < 5; ++i ) {
+            std::vector<data::CellData> simProps{{"KRO" , UnitSystem::measure::identity , std::vector<double>(3*3*3 , i)},
+                                                 {"KRG" , UnitSystem::measure::identity , std::vector<double>(3*3*3 , i*10)}};
+
             eclWriter.writeTimeStep( i,
                                      false,
                                      first_step - start_time,
                                      createBlackoilState( i, 3 * 3 * 3 ),
-                                     wells);
+                                     wells,
+                                     simProps);
 
             checkRestartFile( i );
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -134,9 +134,10 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
         };
 
         eclipseWriter.writeTimeStep( 2,
-                step_time - start_time,
-                createBlackoilState( 2, numCells ),
-                wells, false);
+                                     false,
+                                     step_time - start_time,
+                                     createBlackoilState( 2, numCells ),
+                                     wells);
     }
 
     verifyRFTFile("TESTRFT.RFT");

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -237,8 +237,9 @@ first_sim(test_work_area_type * test_area) {
     auto wells = mkWells();
 
     eclWriter.writeTimeStep( 1,
+                             false,
                              first_step - start_time,
-                             sol, wells, false);
+                             sol, wells);
 
     return { sol, wells };
 }

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -159,9 +159,10 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
 
     for(int timestep = 0; timestep <= countTimeStep; ++timestep){
         eclipseWriter.writeTimeStep( timestep,
+                                     false, 
                                      timestep,
                                      solution,
-                                     wells, false);
+                                     wells );
     }
 
     verifyWellState(eclipse_restart_filename, eclipseState->getInputGrid(), eclipseState->getSchedule());


### PR DESCRIPTION
Added the ability for the restart writer to write arbitrary fields in the restart section. Example of such a field would be the relperms KRO, KRG and KRW and the fluxes. The fields must be calculated and provided by calling scope - i.e. flow in this case.

If not exactly _work in progress_ this is on a strictly 'good enough' basis; tricky balance to find. There is a minor argument reordering which must be fixed in opm-simulators: https://github.com/OPM/opm-simulators/pull/795
