### PR TITLE
Outputwriter: use EclipseGrid

### DIFF
--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -46,9 +46,8 @@ public:
      * \brief Sets the common attributes required to write eclipse
      *        binary files using ERT.
      */
-    EclipseWriter(std::shared_ptr< const EclipseState >,
-                  int numCells,
-                  const int* compressedToCartesianCellIdx);
+    EclipseWriter(std::shared_ptr< const EclipseState >, EclipseGrid grid);
+
 
 
 
@@ -99,8 +98,9 @@ public:
     ~EclipseWriter();
 
 private:
-    void writeINITFile( const EclipseGrid& grid, const std::vector<data::CellData>& simProps, const NNC& nnc) const;
+    void writeINITFile( const std::vector<data::CellData>& simProps, const NNC& nnc) const;
     void writeEGRIDFile( const NNC& nnc) const;
+    void init();
 
     class Impl;
     std::unique_ptr< Impl > impl;

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -123,7 +123,7 @@ struct fn_args {
     const data::Wells& wells;
     const data::Solution& state;
     const std::unordered_map<int , std::vector<size_t>>& regionCells;
-    const std::vector<int>& compressedToCartesian;
+    const GridDims& grid;
 };
 
 /* Since there are several enums in opm scattered about more-or-less
@@ -548,7 +548,8 @@ Summary::Summary( const EclipseState& st,
         const auto handle = funs.find( keyword )->second;
         const std::vector< const Well* > dummy_wells;
         const std::unordered_map<int,std::vector<size_t>> dummy_cells;
-        const fn_args no_args{ dummy_wells, 0, 0, 0, {} , {}, dummy_cells , {} };
+        GridDims dummy_grid(1,1,1);
+        const fn_args no_args{ dummy_wells, 0, 0, 0, {} , {}, dummy_cells , dummy_grid };
         const auto val = handle( no_args );
         const auto* unit = st.getUnits().name( val.unit );
 
@@ -561,7 +562,7 @@ Summary::Summary( const EclipseState& st,
 
 void Summary::add_timestep( int report_step,
                             double secs_elapsed,
-                            const std::vector<int>& indexMap,
+                            const EclipseGrid& grid,
                             const EclipseState& es,
                             const std::unordered_map<int, std::vector<size_t>>& regionCells,
                             const data::Wells& wells ,
@@ -578,7 +579,7 @@ void Summary::add_timestep( int report_step,
         const auto* genkey = smspec_node_get_gen_key1( f.first );
 
         const auto schedule_wells = find_wells( schedule, f.first, timestep );
-        const auto val = f.second( { schedule_wells, duration, timestep, num, wells , state , regionCells , indexMap} );
+        const auto val = f.second( { schedule_wells, duration, timestep, num, wells , state , regionCells , grid} );
 
         const auto num_val = val.value > 0 ? val.value : 0.0;
         const auto unit_applied_val = es.getUnits().from_si( val.unit, num_val );

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -27,6 +27,8 @@
 #include <ert/ecl/ecl_sum.h>
 #include <ert/ecl/Smspec.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
 #include <opm/output/Wells.hpp>
 #include <opm/output/Cells.hpp>
 
@@ -46,7 +48,7 @@ class Summary {
 
         void add_timestep( int report_step,
                            double secs_elapsed,
-                           const std::vector<int>& indexMap,
+                           const EclipseGrid& grid, 
                            const EclipseState& es,
                            const std::unordered_map<int, std::vector<size_t>>& regionCells,
                            const data::Wells&,

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
 
     {
         ERT::TestArea ta("test_ecl_writer");
-        EclipseWriter eclWriter( es, 3 * 3 * 3, nullptr);
+        EclipseWriter eclWriter( es, eclGrid);
 
         auto start_time = util_make_datetime( 0, 0, 0, 10, 10, 2008 );
         auto first_step = util_make_datetime( 0, 0, 0, 10, 11, 2008 );

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -117,8 +117,9 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
          */
 
         const auto numCells = eclipseState->getInputGrid()->getCartesianSize( );
+        const auto& grid = *eclipseState->getInputGrid();
 
-        EclipseWriter eclipseWriter( eclipseState, numCells, nullptr );
+        EclipseWriter eclipseWriter( eclipseState, grid);
         time_t start_time = eclipseState->getSchedule()->posixStartTime();
         /* step time read from deck and hard-coded here */
         time_t step_time = util_make_datetime( 0, 0, 0, 10, 10, 2008 );

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -229,7 +229,7 @@ first_sim(test_work_area_type * test_area) {
     const auto& grid = *eclipseState->getInputGrid();
     auto num_cells = grid.getNX() * grid.getNY() * grid.getNZ();
 
-    EclipseWriter eclWriter( eclipseState, num_cells, nullptr );
+    EclipseWriter eclWriter( eclipseState, grid);
     auto start_time = util_make_datetime( 0, 0, 0, 1, 11, 1979 );
     auto first_step = util_make_datetime( 0, 0, 0, 10, 10, 2008 );
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -155,7 +155,6 @@ struct setup {
     EclipseState es;
     SummaryConfig config;
     const EclipseGrid& grid;
-    const std::vector<int> am;
     data::Wells wells;
     std::string name;
     ERT::TestArea ta;
@@ -170,7 +169,6 @@ struct setup {
         es( *deck, ParseContext() ),
         config( *deck, es , parseContext ),
         grid( *es.getInputGrid() ),
-        am( grid.getActiveMap() ),
         wells( result_wells() ),
         name( fname ),
         ta( ERT::TestArea("test_summary") )
@@ -180,7 +178,7 @@ struct setup {
         const auto& region_values = properties.getRegions( "FIPNUM" );
 
         for (auto region_id : region_values)
-            cells.emplace( region_id , fipnum.cellsEqual( region_id , am ));
+            cells.emplace( region_id , fipnum.cellsEqual( region_id , grid ));
 
         solution = make_solution( *es.getInputGrid());
     }
@@ -200,9 +198,9 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     cfg.name = "PATH/CASE";
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 1 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 2 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 0, 0 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 1 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 2 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -323,9 +321,9 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_Summary_group" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 1 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 2 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 0, 0 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 1 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 2 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -395,9 +393,9 @@ BOOST_AUTO_TEST_CASE(completion_kewords) {
     setup cfg( "test_Summary_completion" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 1 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 2 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 0, 0 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 1 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 2 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -435,9 +433,9 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     setup cfg( "test_Summary_field" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 1 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 2 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 0, 0 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 1 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 2 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -512,9 +510,9 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_Summary_report_steps_time" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 1, 2 *  day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 5 *  day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 10 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 2 *  day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 5 *  day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 10 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -534,9 +532,9 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_Summary_skip_unknown_var" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.name );
-    writer.add_timestep( 1, 2 *  day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 1, 5 *  day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
-    writer.add_timestep( 2, 10 * day, cfg.am, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 2 *  day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 1, 5 *  day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
+    writer.add_timestep( 2, 10 * day, cfg.grid, cfg.es, cfg.cells, cfg.wells , cfg.solution);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -554,9 +552,9 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.name );
-        writer.add_timestep( 1, 2 *  day, cfg.am , cfg.es, cfg.cells, cfg.wells, cfg.solution);
-        writer.add_timestep( 1, 5 *  day, cfg.am , cfg.es, cfg.cells, cfg.wells, cfg.solution);
-        writer.add_timestep( 2, 10 * day, cfg.am , cfg.es, cfg.cells, cfg.wells, cfg.solution);
+        writer.add_timestep( 1, 2 *  day, cfg.grid , cfg.es, cfg.cells, cfg.wells, cfg.solution);
+        writer.add_timestep( 1, 5 *  day, cfg.grid , cfg.es, cfg.cells, cfg.wells, cfg.solution);
+        writer.add_timestep( 2, 10 * day, cfg.grid , cfg.es, cfg.cells, cfg.wells, cfg.solution);
         writer.write();
     }
 

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     auto es = Parser::parse( eclipse_data_filename, ParseContext() );
     auto eclipseState = std::make_shared< EclipseState >( es );
     const auto num_cells = eclipseState->getInputGrid()->getCartesianSize();
-    EclipseWriter eclipseWriter( eclipseState, num_cells, nullptr );
+    EclipseWriter eclipseWriter( eclipseState,  *eclipseState->getInputGrid());
 
     int countTimeStep = eclipseState->getSchedule()->getTimeMap()->numTimesteps();
 


### PR DESCRIPTION
- The outputwriter will now take a a separate EclipseGrid instance as
  input argument, it is assumed that calling scope has already made sure
  ACTNUM and ZCORN are correct.
- All active/inactive cell mappings are based on the grid argument, the
  naked int\* with global / active cell mappings has been completely
  removed.

Upstream: https://github.com/OPM/opm-parser/pull/915
Downstream: https://github.com/OPM/opm-simulators/pull/814
