### PR TITLE
Overwrite old unrst

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -311,6 +311,7 @@ class RFT {
              const EclipseGrid& grid_);
 
         void writeTimeStep( std::vector< const Well* >,
+                            const EclipseGrid& grid,
                             int report_step,
                             time_t current_time,
                             double days,
@@ -344,6 +345,7 @@ inline ert_ecl_unit_enum to_ert_unit( UnitSystem::UnitType t ) {
 }
 
 void RFT::writeTimeStep( std::vector< const Well* > wells,
+                         const EclipseGrid& grid,
                          int report_step,
                          time_t current_time,
                          double days,
@@ -747,6 +749,7 @@ void EclipseWriter::writeTimeStep(int report_step,
 
     const auto unit_type = es.getDeckUnitSystem().getType();
     this->impl->rft.writeTimeStep( schedule.getWells( report_step ),
+                                   grid,
                                    report_step,
                                    current_posix_time,
                                    days,

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -310,7 +310,6 @@ private:
     Restart& restart;
 };
 
-
 /// Convert OPM phase usage to ERT bitmask
 inline int ertPhaseMask( const TableManager& tm ) {
     return ( tm.hasPhase( Phase::PhaseEnum::WATER ) ? ECL_WATER_PHASE : 0 )
@@ -322,8 +321,7 @@ class RFT {
     public:
         RFT( const char* output_dir,
              const char* basename,
-             bool format,
-             const EclipseGrid& grid_);
+             bool format );
 
         void writeTimeStep( std::vector< const Well* >,
                             const EclipseGrid& grid,
@@ -336,18 +334,14 @@ class RFT {
                             const std::vector< double >& sgas );
     private:
         ERT::FortIO fortio;
-        const EclipseGrid& grid;
 };
 
 
 RFT::RFT( const char* output_dir,
           const char* basename,
-          bool format,
-          const EclipseGrid& grid_ ) :
-    fortio(FileName( output_dir, basename, ECL_RFT_FILE, format ).get(),std::ios_base::out),
-    grid( grid_ )
-{
-}
+          bool format ) :
+    fortio(FileName( output_dir, basename, ECL_RFT_FILE, format ).get(),std::ios_base::out)
+{}
 
 inline ert_ecl_unit_enum to_ert_unit( UnitSystem::UnitType t ) {
     switch ( t ) {
@@ -438,9 +432,7 @@ EclipseWriter::Impl::Impl( std::shared_ptr< const EclipseState > eclipseState,
     , outputDir( eclipseState->getIOConfig()->getOutputDir() )
     , baseName( uppercase( eclipseState->getIOConfig()->getBaseName() ) )
     , summary( *eclipseState, eclipseState->getSummaryConfig() )
-    , rft( outputDir.c_str(), baseName.c_str(),
-           es->getIOConfig()->getFMTOUT(),
-           grid)
+    , rft( outputDir.c_str(), baseName.c_str(), es->getIOConfig()->getFMTOUT() )
     , sim_start_time( es->getSchedule()->posixStartTime() )
     , output_enabled( eclipseState->getIOConfig()->getOutputEnabled() )
     , ert_phase_mask( ertPhaseMask( eclipseState->getTableManager() ) )
@@ -454,9 +446,7 @@ EclipseWriter::Impl::Impl( std::shared_ptr< const EclipseState > eclipseState,
     , outputDir( eclipseState->getIOConfig()->getOutputDir() )
     , baseName( uppercase( eclipseState->getIOConfig()->getBaseName() ) )
     , summary( *eclipseState, eclipseState->getSummaryConfig() )
-    , rft( outputDir.c_str(), baseName.c_str(),
-           es->getIOConfig()->getFMTOUT(),
-           grid)
+    , rft( outputDir.c_str(), baseName.c_str(), es->getIOConfig()->getFMTOUT() )
     , sim_start_time( es->getSchedule()->posixStartTime() )
     , output_enabled( eclipseState->getIOConfig()->getOutputEnabled() )
     , ert_phase_mask( ertPhaseMask( eclipseState->getTableManager() ) )


### PR DESCRIPTION
Replaces checking if the report step is zero with maintaining some state
and determining if any given step is the first time an UNRST file is
written to or not. Extends the test to also cover this case.

Supersedes https://github.com/OPM/opm-output/pull/61 and addresses https://github.com/OPM/opm-simulators/issues/753
