### PR TITLE
Fix compile issue and warnings

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -313,7 +313,6 @@ class RFT {
              const EclipseGrid& grid_);
 
         void writeTimeStep( std::vector< const Well* >,
-                            const EclipseGrid& grid,
                             int report_step,
                             time_t current_time,
                             double days,
@@ -347,7 +346,6 @@ inline ert_ecl_unit_enum to_ert_unit( UnitSystem::UnitType t ) {
 }
 
 void RFT::writeTimeStep( std::vector< const Well* > wells,
-                         const EclipseGrid& grid,
                          int report_step,
                          time_t current_time,
                          double days,
@@ -751,7 +749,6 @@ void EclipseWriter::writeTimeStep(int report_step,
 
     const auto unit_type = es.getDeckUnitSystem().getType();
     this->impl->rft.writeTimeStep( schedule.getWells( report_step ),
-                                   grid,
                                    report_step,
                                    current_posix_time,
                                    days,

--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -296,8 +296,6 @@ private:
 };
 
 
-const int inactive_index = -1;
-
 /// Convert OPM phase usage to ERT bitmask
 inline int ertPhaseMask( const TableManager& tm ) {
     return ( tm.hasPhase( Phase::PhaseEnum::WATER ) ? ECL_WATER_PHASE : 0 )

--- a/opm/test_util/EclFilesComparator.cpp
+++ b/opm/test_util/EclFilesComparator.cpp
@@ -59,7 +59,7 @@ unsigned int ECLFilesComparator::getEclKeywordData(ecl_kw_type*& ecl_kw1, ecl_kw
 
 
 template <typename T>
-void ECLFilesComparator::printValuesForCell(const std::string& keyword, int occurrence1, int occurrence2, size_t cell, const T& value1, const T& value2) const {
+void ECLFilesComparator::printValuesForCell(const std::string& /*keyword*/, int occurrence1, int occurrence2, size_t cell, const T& value1, const T& value2) const {
     int i, j, k;
     ecl_grid_get_ijk1(ecl_grid1, cell, &i, &j, &k);
     // Coordinates from this function are zero-based, hence incrementing
@@ -77,10 +77,10 @@ template void ECLFilesComparator::printValuesForCell<std::string>(const std::str
 
 
 
-ECLFilesComparator::ECLFilesComparator(int file_type, const std::string& basename1,
+ECLFilesComparator::ECLFilesComparator(int file_type_arg, const std::string& basename1,
                                        const std::string& basename2,
-                                       double absTolerance, double relTolerance) :
- file_type(file_type), absTolerance(absTolerance), relTolerance(relTolerance) {
+                                       double absToleranceArg, double relToleranceArg) :
+ file_type(file_type_arg), absTolerance(absToleranceArg), relTolerance(relToleranceArg) {
 
     std::string file1, file2;
     if (file_type == ECL_UNIFIED_RESTART_FILE) {

--- a/opm/test_util/EclFilesComparator.hpp
+++ b/opm/test_util/EclFilesComparator.hpp
@@ -164,7 +164,7 @@ class RegressionTest: public ECLFilesComparator {
             ECLFilesComparator(file_type, basename1, basename2, absTolerance, relTolerance) {}
 
         //! \brief Option to only compare last occurrence
-        void setOnlyLastOccurrence(bool onlyLastOccurrence) {this->onlyLastOccurrence = onlyLastOccurrence;}
+        void setOnlyLastOccurrence(bool onlyLastOccurrenceArg) {this->onlyLastOccurrence = onlyLastOccurrenceArg;}
 
         //! \brief Compares grid properties of the two cases.
         // gridCompare() checks if both the number of active and global cells in the two cases are the same. If they are, all cells are looped over to calculate the cell volume deviation for the two cases. If the both the relative and absolute deviation exceeds the tolerances, an exception is thrown.

--- a/opm/test_util/summaryIntegrationTest.cpp
+++ b/opm/test_util/summaryIntegrationTest.cpp
@@ -21,6 +21,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <ert/ecl/ecl_sum.h>
 #include <ert/util/stringlist.h>
+#include <cmath>
 
 
 void IntegrationTest::getIntegrationTest(){
@@ -368,7 +369,7 @@ double IntegrationTest::integrateError(const std::vector<double>& timeVec1,
         if(timeVec1[i] == timeVec2[j]){
             rightEdge = timeVec1[i];
             width = rightEdge - leftEdge;
-            double dev = std::abs(dataVec1[i] - dataVec2[j]);
+            double dev = std::fabs(dataVec1[i] - dataVec2[j]);
             errorSum += getRectangleArea(dev, width);
             leftEdge = rightEdge;
             i++;
@@ -379,7 +380,7 @@ double IntegrationTest::integrateError(const std::vector<double>& timeVec1,
             rightEdge = timeVec1[i];
             width = rightEdge - leftEdge;
             double value = unitStep(dataVec2[j]);
-            double dev = std::abs(dataVec1[i]-value);
+            double dev = std::fabs(dataVec1[i]-value);
             errorSum += getRectangleArea(dev, width);
             leftEdge = rightEdge;
             i++;
@@ -389,7 +390,7 @@ double IntegrationTest::integrateError(const std::vector<double>& timeVec1,
             rightEdge = timeVec2[j];
             width = rightEdge - leftEdge;
             double value = unitStep(dataVec1[i]);
-            double dev = std::abs(dataVec2[j]-value);
+            double dev = std::fabs(dataVec2[j]-value);
             errorSum += getRectangleArea(dev, width);
             leftEdge = rightEdge;
             j++;

--- a/opm/test_util/summaryIntegrationTest.hpp
+++ b/opm/test_util/summaryIntegrationTest.hpp
@@ -129,17 +129,17 @@ class IntegrationTest: public SummaryComparator {
         //! \brief This function sets the private member variable allowSpikes.
         //! \param[in] allowSpikes Boolean value
         //! \details When allowSpikes is true, the integration test checkWithSpikes is excecuted.
-        void setAllowSpikes(bool allowSpikes){this->allowSpikes = allowSpikes;}
+        void setAllowSpikes(bool allowSpikesArg){this->allowSpikes = allowSpikesArg;}
 
         //! \brief This function sets the private member variable findVolumeError.
         //! \param[in] findVolumeError Boolean value
         //! \details When findVolumeError is true, the integration test volumeErrorCheck and the function evaluateWellProductionVolume are excecuted.
-        void setFindVolumeError(bool findVolumeError){this->findVolumeError = findVolumeError;}
+        void setFindVolumeError(bool findVolumeErrorArg){this->findVolumeError = findVolumeErrorArg;}
 
         //! \brief This function sets the private member variable oneOfTheMainVariables
         //! \param[in] oneOfTheMainVariables Boolean value
         //! \details When oneOfTheMainVariables is true, the integration test runs the substest volumeErrorCheckForOneSpecificVariable.
-        void setOneOfTheMainVariables(bool oneOfTheMainVariables){this->oneOfTheMainVariables = oneOfTheMainVariables;}
+        void setOneOfTheMainVariables(bool oneOfTheMainVariablesArg){this->oneOfTheMainVariables = oneOfTheMainVariablesArg;}
 
         //! \brief This function sets the member variable string #mainVariable
         //! \param[in] mainVar This is the string should contain one of the main variables. e.g. WOPR

--- a/test_util/compareECL.cpp
+++ b/test_util/compareECL.cpp
@@ -182,7 +182,7 @@ int main(int argc, char** argv) {
 
     if (specificFileType) {
         std::string fileTypeString(fileTypeCstr);
-        for (auto& c: fileTypeString) c = toupper(c);
+        for (auto& ch: fileTypeString) ch = toupper(ch);
         if (fileTypeString== "UNRST") {} //Do nothing
         else if (fileTypeString == "RST") {
             concatenateRestart(basename1);

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -145,7 +145,7 @@ void checkEgridFile( const EclipseGrid& eclGrid ) {
     fortio_fclose(egridFile);
 }
 
-void checkInitFile( const EclipseGrid& grid , const Deck& deck, const std::vector<data::CellData>& simProps) {
+void checkInitFile( const Deck& deck, const std::vector<data::CellData>& simProps) {
     // use ERT directly to inspect the INIT file produced by EclipseWriter
     ERT::ert_unique_ptr<ecl_file_type , ecl_file_close> initFile(ecl_file_open( "FOO.INIT" , 0 ));
 
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration)
             checkRestartFile( i );
 
         }
-        checkInitFile( eclGrid , *deck , eGridProps);
+        checkInitFile( *deck , eGridProps);
         checkEgridFile( eclGrid );
     }
 }


### PR DESCRIPTION
This fixes some recent issues on my platform.

Please verify that it is correct to remove the grid argument of RFT::writeTimeStep(). The function then uses the data member `grid` instead of the one that used to be passed to writeTimeStep().
