### PR TITLE
Return zero for non-existing well/completion

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -104,28 +104,33 @@ namespace Opm {
     public:
 
         double get(const std::string& well_name , Rates::opt m) const {
-            const auto& well = this->at(well_name);
-            return well.rates.get( m );
+            const auto& well = this->find( well_name );
+            if( well == this->end() ) return 0.0;
+
+            return well->second.rates.get( m, 0.0 );
         }
 
 
         double get(const std::string& well_name , Completion::active_index completion_grid_index, Rates::opt m) const {
-            const auto& well = this->at(well_name);
+            const auto& witr = this->find( well_name );
+            if( witr == this->end() ) return 0.0;
+
+            const auto& well = witr->second;
             const auto& completion = std::find_if( well.completions.begin() ,
                                                    well.completions.end() ,
                                                    [=]( const Completion& c ) {
                                                         return c.index == completion_grid_index; });
-            if (completion == well.completions.end())
-                throw std::out_of_range("No such completion");
 
-            return completion->rates.get( m );
+            if( completion == well.completions.end() )
+                return 0.0;
+
+            return completion->rates.get( m, 0.0 );
         }
 
-
     };
+
     using Wells = WellRates;
 
-    //using Wells = std::map<std::string , Well>;
     /* IMPLEMENTATIONS */
 
     inline bool Rates::has( opt m ) const {

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -344,7 +344,10 @@ quantity region_sum( const fn_args& args , const std::string& keyword , UnitSyst
 
     double sum = 0;
 
-    const std::vector<double>& sim_value = args.state.data( keyword);
+    if( args.state.count( keyword ) == 0 )
+        return { 0.0, unit };
+
+    const std::vector<double>& sim_value = args.state.data( keyword );
 
     for (auto cell_index : cells)
         sum += sim_value[cell_index];

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -530,3 +530,16 @@ TSTEP
 -- up historical rates and volumes. These volumes however don't change, i.e.
 -- every time step has the same set of values
 10 10 /
+
+-- Register a fourth well with completions later. This ensure we handle when
+-- wells are registered or activated later in a simulation
+WELSPECS
+     'W_4'        'G_3'   1    1  3.33       'OIL'  7* /
+/
+
+COMPDAT
+    W_4 1 1 3 3 /
+/
+
+TSTEP
+10 10 /

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -121,9 +121,9 @@ BOOST_AUTO_TEST_CASE(get_completions) {
     wellRates["OP_1"] = w1;
     wellRates["OP_2"] = w2;
 
-    BOOST_CHECK_THROW( wellRates.get("NO_SUCH_WELL" , data::Rates::opt::wat), std::out_of_range);
+    BOOST_CHECK_EQUAL( 0.0, wellRates.get("NO_SUCH_WELL" , data::Rates::opt::wat) );
     BOOST_CHECK_EQUAL( 5.67 , wellRates.get( "OP_1" , data::Rates::opt::wat));
 
-    BOOST_CHECK_THROW( wellRates.get("OP_2" , 10000 , data::Rates::opt::wat), std::out_of_range);
+    BOOST_CHECK_EQUAL( 0.0, wellRates.get("OP_2" , 10000 , data::Rates::opt::wat) );
     BOOST_CHECK_EQUAL( 26.41 , wellRates.get( "OP_2" , 188 , data::Rates::opt::wat));
 }

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(create) {
     BOOST_CHECK_EQUAL( c.size() , 0 );
 
     {
-        const auto& empty = rc.completions( 3 );
+        const auto& empty = rc.completions( 4 );
         BOOST_CHECK_EQUAL( empty.size() , 0 );
     }
 


### PR DESCRIPTION
To be consistent with the general summary behaviour and more input
tolerant, 0.0 is returned when some phase, completion or well is
requested that isn't provided by the simulator.

Solves the issue discussed in https://github.com/OPM/opm-output/pull/122
and extends the test input deck to trigger this behaviour.