### PR TITLE
FOE support

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -559,7 +559,7 @@ void EclipseWriter::Impl::writeEGRIDFile( const NNC& nnc ) const {
 }
 
 
-void EclipseWriter::writeInitAndEgrid(data::Solution simProps, const NNC& nnc) {
+void EclipseWriter::writeInitial( data::Solution simProps, const NNC& nnc) {
     if( !this->impl->output_enabled )
         return;
 
@@ -574,6 +574,8 @@ void EclipseWriter::writeInitAndEgrid(data::Solution simProps, const NNC& nnc) {
         if( ioConfig.getWriteEGRIDFile( ) )
             this->impl->writeEGRIDFile( nnc );
     }
+
+    this->impl->summary.set_initial( simProps );
 }
 
 std::vector< double > serialize_XWEL( const data::Wells& wells,
@@ -655,7 +657,6 @@ std::vector< int > serialize_IWEL( const data::Wells& wells,
 
     return iwel;
 }
-
 
 // implementation of the writeTimeStep method
 void EclipseWriter::writeTimeStep(int report_step,

--- a/opm/output/eclipse/EclipseWriter.hpp
+++ b/opm/output/eclipse/EclipseWriter.hpp
@@ -53,7 +53,8 @@ public:
 
 
 
-    /// Write the static eclipse data (grid, PVT curves, etc) to disk.
+    /// Write the static eclipse data (grid, PVT curves, etc) to disk, and set
+    /// up additional initial properties
     ///
     /// - simProps contains a list of properties which must be
     ///   calculated by the simulator, e.g. the transmissibility
@@ -61,7 +62,10 @@ public:
     ///
     /// - The NNC argument is distributed between the EGRID and INIT
     ///   files.
-    void writeInitAndEgrid(data::Solution simProps = data::Solution( ), const NNC& nnc = NNC());
+    ///
+    /// If you want FOE in the SUMMARY section, you must pass the initial
+    /// oil-in-place "OIP" key in Solution
+    void writeInitial( data::Solution = data::Solution(), const NNC& = NNC());
 
     /*!
      * \brief Write a reservoir state and summary information to disk.

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -134,6 +134,10 @@ struct quantity {
     }
 };
 
+quantity operator-( double lhs, const quantity& rhs ) {
+    return { lhs - rhs.value, rhs.unit };
+}
+
 /*
  * All functions must have the same parameters, so they're gathered in a struct
  * and functions use whatever information they care about.
@@ -150,6 +154,7 @@ struct fn_args {
     const data::Solution& state;
     const out::RegionCache& regionCache;
     const EclipseGrid& grid;
+    double initial_oip;
 };
 
 /* Since there are several enums in opm scattered about more-or-less
@@ -411,7 +416,10 @@ quantity foip( const fn_args& args ) {
              measure::volume };
 }
 
-
+quantity foe( const fn_args& args ) {
+    const quantity val = { foip( args ).value, measure::identity };
+    return (args.initial_oip - val) / args.initial_oip;
+}
 
 template< typename F, typename G >
 auto mul( F f, G g ) -> bin_op< F, G, std::multiplies< quantity > >
@@ -598,6 +606,7 @@ static const std::unordered_map< std::string, ofun > funs = {
 
     { "FOIP", foip },
     { "FGIP", fgip },
+    { "FOE",  foe },
 
     { "FWPRH", production_history< Phase::WATER > },
     { "FOPRH", production_history< Phase::OIL > },
@@ -758,7 +767,8 @@ Summary::Summary( const EclipseState& st,
                                 {},          // Well results - data::Wells
                                 {},          // EclipseState
                                 {},          // Region <-> cell mappings.
-                                this->grid };
+                                this->grid,
+                                this->initial_oip };
 
         const auto val = handle( no_args );
         const auto* unit = st.getUnits().name( val.unit );
@@ -787,7 +797,15 @@ void Summary::add_timestep( int report_step,
         const auto* genkey = smspec_node_get_gen_key1( f.first );
 
         const auto schedule_wells = find_wells( schedule, f.first, timestep );
-        const auto val = f.second( { schedule_wells, duration, timestep, num, wells , state , regionCache , this->grid} );
+        const auto val = f.second( { schedule_wells,
+                                     duration,
+                                     timestep,
+                                     num,
+                                     wells,
+                                     state,
+                                     regionCache,
+                                     this->grid,
+                                     this->initial_oip } );
 
         const auto unit_applied_val = es.getUnits().from_si( val.unit, val.value );
         const auto res = smspec_node_is_total( f.first ) && prev_tstep
@@ -799,6 +817,13 @@ void Summary::add_timestep( int report_step,
 
     this->prev_tstep = tstep;
     this->prev_time_elapsed = secs_elapsed;
+}
+
+void Summary::set_initial( const data::Solution& sol ) {
+    if( !sol.has( "OIP" ) ) return;
+
+    const auto& cells = sol.at( "OIP" ).data;
+    this->initial_oip = std::accumulate( cells.begin(), cells.end(), 0.0 );
 }
 
 void Summary::write() {

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -57,6 +57,8 @@ class Summary {
                            const RegionCache& regionCache,
                            const data::Wells&,
                            const data::Solution& );
+
+        void set_initial( const data::Solution& );
         void write();
 
         ~Summary();
@@ -69,6 +71,7 @@ class Summary {
         std::unique_ptr< keyword_handlers > handlers;
         const ecl_sum_tstep_type* prev_tstep = nullptr;
         double prev_time_elapsed = 0;
+        double initial_oip = 0.0;
 };
 
 }

--- a/tests/test_EclipseWriter.cpp
+++ b/tests/test_EclipseWriter.cpp
@@ -291,8 +291,8 @@ BOOST_AUTO_TEST_CASE(EclipseWriterIntegration) {
         };
 
 
-        eclWriter.writeInitAndEgrid( );
-        eclWriter.writeInitAndEgrid( eGridProps );
+        eclWriter.writeInitial( );
+        eclWriter.writeInitial( eGridProps );
 
         data::Wells wells;
 


### PR DESCRIPTION
Field efficiency: (OIP(initial) - OIP(now)) / OIP(initial). The initial
OIP is cached, and FOIP is reused for OIP(now). Adds the
operator-(double,quantity) to make the formula obvious from the FOE
function.

@atgeirr @babrodtk I'd appreciate some help on the simulator side of this. Somewhere around https://github.com/OPM/opm-simulators/blob/master/opm/autodiff/SimulatorBase_impl.hpp#L190 you'd need to call `setInitial` with OIP passed.