### PR TITLE
Changed build order for ewoms in jenkins/build.sh

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -20,9 +20,9 @@ declare -a downstreams
 downstreams=(opm-material
              opm-core
              opm-grid
+             ewoms
              opm-simulators
-             opm-upscaling
-             ewoms)
+             opm-upscaling)
 
 declare -A downstreamRev
 downstreamRev[opm-material]=master


### PR DESCRIPTION
This commit was originally by @akva2 - but it was lost in a rebase, I have recreated it here.