### PR TITLE
Solution data::solution has SI units in Summary.

### DIFF
--- a/opm/output/eclipse/EclipseWriter.cpp
+++ b/opm/output/eclipse/EclipseWriter.cpp
@@ -684,7 +684,7 @@ void EclipseWriter::writeTimeStep(int report_step,
     const auto& es = this->impl->es;
     const auto& grid = this->impl->grid;
     const auto& units = es.getUnits();
-
+    const data::Solution cells_si = cells;
     const auto& restart = es.cfg().restart();
 
 
@@ -818,7 +818,7 @@ void EclipseWriter::writeTimeStep(int report_step,
                                       this->impl->es,
                                       this->impl->regionCache,
                                       wells ,
-                                      cells );
+                                      cells_si );
     this->impl->summary.write();
  }
 


### PR DESCRIPTION
The solution data which was passed to the summary for calculation of e.g. `BPR` was converted from SI units twice. The current PR implements a temporary fix to facilitate update of reference data.

This is is the third time in a short period which has required updates to the reference data, I assume there will be more. Common to these three updates is the following:

1. The error has been gross, wrong units, and a naive comparison with the Eclipse reference solution would have revealed it immediately.
2. The error has been in keywords/results no one has really been interested in, and the results have been printed to output in a sort of whatever-hang along mode.

To reduce the effort and noise related to updating the reference data I wish we could change the testing to:

1. More active use of the eclipse data as reference data.
2. More selective approach to what is actually compared in the regression tests, i.e. we should consciously say that now e.g. 'BPR' is correctly calculated - from now on I want regression testing on this keyword. 