### PR TITLE
Spelling fix

### DIFF
--- a/opm/output/data/Cells.hpp
+++ b/opm/output/data/Cells.hpp
@@ -41,7 +41,7 @@ namespace data {
        suturation. WIll end up in the SOLUTION section of the restart
        file.
 
-     RESTART_AUXILLARY : Fields with extra information, not required
+     RESTART_AUXILIARY : Fields with extra information, not required
        for restart. Examples of this include fluid in place values or
        evaluations of relative permeability. Will end up in the
        restart file.
@@ -57,7 +57,7 @@ namespace data {
 
     enum class TargetType {
         RESTART_SOLUTION,
-        RESTART_AUXILLARY,
+        RESTART_AUXILIARY,
         SUMMARY,
         INIT,
     };

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -454,7 +454,7 @@ void writeSolution(ecl_rst_file_type* rst_file, const data::Solution& solution) 
      ecl_rst_file_end_solution( rst_file );
 
      for (const auto& elm: solution) {
-        if (elm.second.target == data::TargetType::RESTART_AUXILLARY)
+        if (elm.second.target == data::TargetType::RESTART_AUXILIARY)
             ecl_rst_file_add_kw( rst_file , ERT::EclKW<float>(elm.first, elm.second.data).get());
      }
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -298,8 +298,8 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 
         for( int i = first; i < last; ++i ) {
             data::Solution sol = createBlackoilState( i, 3 * 3 * 3 );
-            sol.insert("KRO", measure::identity , std::vector<double>(3*3*3 , i), TargetType::RESTART_AUXILLARY);
-            sol.insert("KRG", measure::identity , std::vector<double>(3*3*3 , i*10), TargetType::RESTART_AUXILLARY);
+            sol.insert("KRO", measure::identity , std::vector<double>(3*3*3 , i), TargetType::RESTART_AUXILIARY);
+            sol.insert("KRG", measure::identity , std::vector<double>(3*3*3 , i*10), TargetType::RESTART_AUXILIARY);
 
 
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -99,13 +99,13 @@ static data::Solution make_solution( const EclipseGrid& grid ) {
         }
 
         sol.insert( "PRESSURE", UnitSystem::measure::pressure , pres , data::TargetType::RESTART_SOLUTION);
-        sol.insert( "OIP"     , UnitSystem::measure::volume   , roip , data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "OIPL"    , UnitSystem::measure::volume   , roipl, data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "OIPG"    , UnitSystem::measure::volume   , roipg, data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "GIP"     , UnitSystem::measure::volume   , rgip , data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "GIPL"    , UnitSystem::measure::volume   , rgipl, data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "GIPG"    , UnitSystem::measure::volume   , rgipg, data::TargetType::RESTART_AUXILLARY);
-        sol.insert( "WIP"     , UnitSystem::measure::volume   , rwip , data::TargetType::RESTART_AUXILLARY);
+        sol.insert( "OIP"     , UnitSystem::measure::volume   , roip , data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "OIPL"    , UnitSystem::measure::volume   , roipl, data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "OIPG"    , UnitSystem::measure::volume   , roipg, data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "GIP"     , UnitSystem::measure::volume   , rgip , data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "GIPL"    , UnitSystem::measure::volume   , rgipl, data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "GIPG"    , UnitSystem::measure::volume   , rgipg, data::TargetType::RESTART_AUXILIARY);
+        sol.insert( "WIP"     , UnitSystem::measure::volume   , rwip , data::TargetType::RESTART_AUXILIARY);
     }
     return sol;
 }
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(foe_test) {
 
     std::vector< double > oip( cfg.grid.getNumActive(), 12.0 );
     data::Solution sol;
-    sol.insert( "OIP", UnitSystem::measure::volume, oip, data::TargetType::RESTART_AUXILLARY );
+    sol.insert( "OIP", UnitSystem::measure::volume, oip, data::TargetType::RESTART_AUXILIARY );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.name );
     writer.set_initial( sol );


### PR DESCRIPTION
This fixes spelling of auxiliary, which I think by mistake has been spelled auxillary (double l) in opm-output and also opm-simulators. 

This PR requires that the sibling PR in opm-simulators is also merged. 

Sibling PR is here: OPM/opm-simulators#1059