### PR TITLE
Added ability to save restart fields in double.

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -386,7 +386,8 @@ void EclipseIO::writeTimeStep(int report_step,
                               bool  isSubstep,
                               double secs_elapsed,
                               data::Solution cells,
-                              data::Wells wells)
+                              data::Wells wells,
+			      bool write_double)
  {
 
     if( !this->impl->output_enabled )
@@ -427,7 +428,7 @@ void EclipseIO::writeTimeStep(int report_step,
                                                  report_step,
                                                  ioConfig.getFMTOUT() );
 
-        RestartIO::save( filename , report_step, secs_elapsed, cells, wells, es , grid);
+        RestartIO::save( filename , report_step, secs_elapsed, cells, wells, es , grid , write_double);
     }
 
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -119,13 +119,20 @@ public:
      * permeabilities KRO, KRW and KRG and fluxes. The keywords which
      * can be added here are represented with mnenonics in the RPTRST
      * keyword.
+     *
+     * If the optional argument write_double is sent in as true the
+     * fields in the solution container will be written in double
+     * precision. OPM can load and restart from files with double
+     * precision keywords, but this is non-standard, and other third
+     * party applications might choke on those.
      */
 
     void writeTimeStep( int report_step,
                         bool isSubstep,
                         double seconds_elapsed,
                         data::Solution,
-                        data::Wells);
+                        data::Wells,
+			bool write_double = false);
 
 
     /*

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -76,7 +76,8 @@ void save(const std::string& filename,
           data::Solution cells,
           data::Wells wells,
           const EclipseState& es,
-          const EclipseGrid& grid);
+          const EclipseGrid& grid,
+	  bool write_double = false);
 
 
 


### PR DESCRIPTION
Observe that just the scaling between SI units and output units is enough to loose bitwise equality.