### PR TITLE
Change in ert data_type for ecl_kw.

### DIFF
--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -36,6 +36,7 @@
 #include <ert/ecl/ecl_init_file.h>
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_type.h>
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_util.h>
 #include <ert/ecl/ecl_rft_file.h>
@@ -90,7 +91,7 @@ namespace {
     std::vector<double> double_vector( const ecl_kw_type * ecl_kw ) {
         size_t size = ecl_kw_get_size( ecl_kw );
 
-        if (ecl_kw_get_type( ecl_kw ) == ECL_DOUBLE_TYPE ) {
+        if (ecl_type_get_type( ecl_kw_get_data_type( ecl_kw ) ) == ECL_DOUBLE_TYPE ) {
             const double * ecl_data = ecl_kw_get_double_ptr( ecl_kw );
             return { ecl_data , ecl_data + size };
         } else {
@@ -464,11 +465,11 @@ void writeHeader(ecl_rst_file_type * rst_file,
       ERT::ert_unique_ptr< ecl_kw_type, ecl_kw_free > kw_ptr;
 
       if (write_double) {
-	  ecl_kw_type * ecl_kw = ecl_kw_alloc( kw.c_str() , data.size() , ECL_DOUBLE_TYPE );
+	  ecl_kw_type * ecl_kw = ecl_kw_alloc( kw.c_str() , data.size() , ECL_DOUBLE );
 	  ecl_kw_set_memcpy_data( ecl_kw , data.data() );
 	  kw_ptr.reset( ecl_kw );
       } else {
-	  ecl_kw_type * ecl_kw = ecl_kw_alloc( kw.c_str() , data.size() , ECL_FLOAT_TYPE );
+	  ecl_kw_type * ecl_kw = ecl_kw_alloc( kw.c_str() , data.size() , ECL_FLOAT );
 	  float * float_data = ecl_kw_get_float_ptr( ecl_kw );
 	  for (size_t i=0; i < data.size(); i++)
 	      float_data[i] = data[i];
@@ -500,7 +501,7 @@ void writeExtraData(ecl_rst_file_type* rst_file, const std::map<std::string,std:
         const std::string& key = pair.first;
         const std::vector<double>& data = pair.second;
         {
-            ecl_kw_type * ecl_kw = ecl_kw_alloc_new_shared( key.c_str() , data.size() , ECL_DOUBLE_TYPE , const_cast<double *>(data.data()));
+            ecl_kw_type * ecl_kw = ecl_kw_alloc_new_shared( key.c_str() , data.size() , ECL_DOUBLE , const_cast<double *>(data.data()));
             ecl_rst_file_add_kw( rst_file , ecl_kw);
             ecl_kw_free( ecl_kw );
         }

--- a/opm/test_util/EclFilesComparator.cpp
+++ b/opm/test_util/EclFilesComparator.cpp
@@ -30,6 +30,7 @@
 
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_grid.h>
+#include <ert/ecl/ecl_type.h>
 
 #include <ert/ecl_well/well_info.h>
 
@@ -181,11 +182,11 @@ ECLFilesComparator::~ECLFilesComparator() {
 void ECLFilesComparator::printKeywords() const {
     std::cout << "\nKeywords in the first file:\n";
     for (const auto& it : keywords1) {
-        std::cout << std::setw(15) << std::left << it << " of type " << ecl_util_get_type_name(ecl_file_iget_named_type(ecl_file1, it.c_str(), 0)) << std::endl;
+        std::cout << std::setw(15) << std::left << it << " of type " << ecl_type_get_name( ecl_file_iget_named_data_type(ecl_file1, it.c_str(), 0)) << std::endl;
     }
     std::cout << "\nKeywords in second file:\n";
     for (const auto& it : keywords2) {
-        std::cout << std::setw(15) << std::left << it << " of type " << ecl_util_get_type_name(ecl_file_iget_named_type(ecl_file2, it.c_str(), 0)) << std::endl;
+        std::cout << std::setw(15) << std::left << it << " of type " << ecl_type_get_name( ecl_file_iget_named_data_type(ecl_file2, it.c_str(), 0)) << std::endl;
     }
 }
 
@@ -262,7 +263,7 @@ double ECLFilesComparator::average(const std::vector<double>& vec) {
 
 void RegressionTest::printResultsForKeyword(const std::string& keyword) const {
     std::cout << "Deviation results for keyword " << keyword << " of type "
-        << ecl_util_get_type_name(ecl_file_iget_named_type(ecl_file1, keyword.c_str(), 0))
+        << ecl_type_get_name(ecl_file_iget_named_data_type(ecl_file1, keyword.c_str(), 0))
         << ":\n";
     const double absDeviationAverage = average(absDeviation);
     const double relDeviationAverage = average(relDeviation);
@@ -450,7 +451,7 @@ void RegressionTest::resultsForKeyword(const std::string keyword) {
                 << "\nThe number of occurrences differ.");
     }
     // Assuming keyword type is constant for every occurrence:
-    const ecl_type_enum kw_type = ecl_file_iget_named_type(ecl_file1, keyword.c_str(), 0);
+    const ecl_type_enum kw_type = ecl_type_get_type( ecl_file_iget_named_data_type(ecl_file1, keyword.c_str(), 0) );
     switch(kw_type) {
         case ECL_DOUBLE_TYPE:
         case ECL_FLOAT_TYPE:
@@ -502,8 +503,7 @@ void RegressionTest::resultsForKeyword(const std::string keyword) {
             }
             break;
         case ECL_MESS_TYPE:
-            std::cout << "\nKeyword " << keyword << " is of type "
-                << ecl_util_get_type_name(kw_type)
+            std::cout << "\nKeyword " << keyword << " is of type MESS"
                 << ", which is not supported in regression test." << "\n\n";
             return;
         default:

--- a/test_util/compareECL.cpp
+++ b/test_util/compareECL.cpp
@@ -85,7 +85,7 @@ void concatenateRestart(const std::string& basename) {
     const char* target_file_name = ecl_util_alloc_filename(inputPath.c_str(), inputBase.c_str(), ECL_UNIFIED_RESTART_FILE, false, -1);
     fortio_type* target = fortio_open_writer(target_file_name, false, ECL_ENDIAN_FLIP);
     int dummy;
-    ecl_kw_type* seqnum_kw = ecl_kw_alloc_new("SEQNUM", 1, ECL_INT_TYPE, &dummy);
+    ecl_kw_type* seqnum_kw = ecl_kw_alloc_new("SEQNUM", 1, ECL_INT, &dummy);
 
     int reportStep = 0;
     for (int i = 0; i < numFiles; ++i) {


### PR DESCRIPTION
This is a followup: https://github.com/Ensembles/ert/pull/1439 - which again is new development to support reading and writing binary files compatible with IX.

Will linger a bit. intention is to merge this and https://github.com/Ensembles/ert/pull/1439 in the week before easter. Will post a message on the mailing list when merging, as this will require a new version of ert.

ewoms: https://github.com/OPM/ewoms/pull/166
opm-upscaling: https://github.com/OPM/opm-upscaling/pull/215
