### PR TITLE
added: put paths to comparison tools in config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,14 @@ include ( ${project}-prereqs )
 # it should set various lists with the names of the files to include
 include (CMakeLists_files.cmake)
 
+# We need to define this variable in the installed cmake config file.
+set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin/compareSummary)
+                                       set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_RPEFIX}/bin/compareECL)")
+
+set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_BINARY_DIR}/bin/compareSummary)
+                                    set(COMPARE_ECL_COMMAND ${CMAKE_BINARY_DIR}/bin/compareECL)")
+
+
 macro (config_hook)
 endmacro (config_hook)
 


### PR DESCRIPTION
necessary for dunecontrol usage.

this fixes the regression tests in opm-simulators for builds based on dunecontrol. @andlaus