### PR TITLE
Allow simulator to overwrite initial OIP value.

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -373,6 +373,10 @@ void EclipseIO::writeInitial( data::Solution simProps, const NNC& nnc) {
 }
 
 
+void  EclipseIO::overwriteInitialOIP( const data::Solution& simProps )
+{
+    this->impl->summary.set_initial( simProps );
+}
 
 // implementation of the writeTimeStep method
 void EclipseIO::writeTimeStep(int report_step,

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -104,6 +104,16 @@ public:
 
     void writeInitial( data::Solution simProps = data::Solution(), const NNC& nnc = NNC());
 
+    /**
+     * \brief Overwrite the initial OIP values.
+     *
+     * These are also written when we call writeInitial if the simProps
+     * contains them. If not these are assumed to zero and the simulator
+     * can update them with this methods.
+     * \param simProps The properties containing at least OIP.
+     */
+    void overwriteInitialOIP( const data::Solution& simProps );
+
     /*!
      * \brief Write a reservoir state and summary information to disk.
      *


### PR DESCRIPTION
Up to now we assumed that if there is interest in the
initial OIP value (e.g. to calculate FOE) then oip has
to be presented to EclipseWriter during the call of
writeInitial. For the downstream simulators OIP is
not available at this stage. This commit gives the simulator
the possibility to overwrite/reset the values later and
allows the current implementations to let output calculate
and output FOE.