### PR TITLE
Fixes typo in variable and path of COMPARE_ECL in opm-output-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,13 @@ include ( ${project}-prereqs )
 include (CMakeLists_files.cmake)
 
 # We need to define this variable in the installed cmake config file.
-set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareSummary)
-                                       set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareECL)")
+set(OPM_PROJECT_EXTRA_CODE_INSTALLED
+	"set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareSummary)
+set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareECL)")
 
-set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_BINARY_DIR}/bin/compareSummary)
-                                    set(COMPARE_ECL_COMMAND ${CMAKE_BINARY_DIR}/bin/compareECL)")
+set(OPM_PROJECT_EXTRA_CODE_INTREE
+  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_BINARY_DIR}/bin/compareSummary)
+set(COMPARE_ECL_COMMAND ${CMAKE_BINARY_DIR}/bin/compareECL)")
 
 
 macro (config_hook)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(opm-common_DIR AND NOT IS_DIRECTORY ${opm-common_DIR})
 endif()
 
 find_package(opm-common REQUIRED)
-
+message("opm-common_CONFIG=${opm-common_CONFIG}")
 include(OpmInit)
 
 # not the same location as most of the other projects; this hook overrides
@@ -67,8 +67,8 @@ include ( ${project}-prereqs )
 include (CMakeLists_files.cmake)
 
 # We need to define this variable in the installed cmake config file.
-set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin/compareSummary)
-                                       set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_RPEFIX}/bin/compareECL)")
+set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareSummary)
+                                       set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareECL)")
 
 set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(COMPARE_SUMMARY_COMMAND ${CMAKE_BINARY_DIR}/bin/compareSummary)
                                     set(COMPARE_ECL_COMMAND ${CMAKE_BINARY_DIR}/bin/compareECL)")


### PR DESCRIPTION
and indentation in that file.