### PR TITLE
Added possiblity: writing integer fields to INIT files.

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -192,7 +192,7 @@ inline std::string uppercase( std::string x ) {
 class EclipseIO::Impl {
     public:
     Impl( const EclipseState&, EclipseGrid, const Schedule&, const SummaryConfig& );
-        void writeINITFile( const data::Solution& simProps, std::map<std::string, std::vector<int> > map, const NNC& nnc) const;
+        void writeINITFile( const data::Solution& simProps, std::map<std::string, std::vector<int> > int_data, const NNC& nnc) const;
         void writeEGRIDFile( const NNC& nnc ) const;
 
         const EclipseState& es;
@@ -221,7 +221,7 @@ EclipseIO::Impl::Impl( const EclipseState& eclipseState,
 
 
 
-void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<std::string, std::vector<int> > map, const NNC& nnc) const {
+void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<std::string, std::vector<int> > int_data, const NNC& nnc) const {
     const auto& units = this->es.getUnits();
     const IOConfig& ioConfig = this->es.cfg().io();
 
@@ -339,9 +339,9 @@ void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<st
 
     //Write Integer Vector Map
     {
-        std::map<std::string, std::vector<int> >::iterator it = map.begin();
+        std::map<std::string, std::vector<int> >::iterator it = int_data.begin();
 
-        while(it != map.end())  {
+        while(it != int_data.end())  {
             std::string key = it->first;
             if (key.size() > ECL_STRING8_LENGTH)
               throw std::invalid_argument("Keyword is too long.");

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -340,16 +340,11 @@ void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<st
     {
         for( const auto& pair : int_data)  {
             const std::string& key = pair.first;
-            const std::vector<int>& int_data = pair.second;
+            const std::vector<int>& int_vector = pair.second;
             if (key.size() > ECL_STRING8_LENGTH)
               throw std::invalid_argument("Keyword is too long.");            
 
-            if (int_data.size() == this->grid.getCartesianSize( ))
-                writeKeyword( fortio , key , int_data );
-            else  {
-                std::vector<int> global_copy = grid.scatterVector( int_data );
-                writeKeyword( fortio , key , global_copy );
-            }
+            writeKeyword( fortio , key , int_vector );
         }
     }
 

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -381,11 +381,7 @@ void EclipseIO::Impl::writeEGRIDFile( const NNC& nnc ) const {
 
 /*
 int_data: Writes key(string) and integers vector to INIT file as eclipse keywords
-- Key: Max 8 chars.
-- vector: Size number of grid cells (N_grid = nx*ny*nz) OR number of active cells.
-    If vector size equals number of active cells, then vector is expanded to size N_grid.
-       - expanded_vector[j] = vector[i], global cell j corresponds to active cell i. 
-       - expanded_vector[j] = default (-1), if j corresponds to an inactive cell.    
+- Key: Max 8 chars.   
 - Wrong input: invalid_argument exception.                                   
 */
 void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std::vector<int> > int_data, const NNC& nnc) {

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -107,7 +107,7 @@ public:
   *     are not yet written to disk.
   */
 
-    void writeInitial( data::Solution simProps = data::Solution(), const NNC& nnc = NNC());
+    void writeInitial( data::Solution simProps = data::Solution(), std::map<std::string, std::vector<int> > map = {}, const NNC& nnc = NNC());
 
     /**
      * \brief Overwrite the initial OIP values.

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -107,7 +107,7 @@ public:
   *     are not yet written to disk.
   */
 
-    void writeInitial( data::Solution simProps = data::Solution(), std::map<std::string, std::vector<int> > map = {}, const NNC& nnc = NNC());
+    void writeInitial( data::Solution simProps = data::Solution(), std::map<std::string, std::vector<int> > int_data = {}, const NNC& nnc = NNC());
 
     /**
      * \brief Overwrite the initial OIP values.

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -43,7 +43,6 @@
 // ERT stuff
 #include <ert/util/ert_unique_ptr.hpp>
 #include <ert/util/TestArea.hpp>
-#include <ert/util/test_util.hpp>
 
 #include <ert/ecl/ecl_kw.h>
 #include <ert/ecl/ecl_grid.h>
@@ -354,11 +353,11 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         checkEgridFile( eclGrid );
         loadWells( "FOO.EGRID", "FOO.UNRST" );
 
-        ecl_file_type * ecl_file = ecl_file_open("./FOO.INIT", 0);
+        ecl_file_type * ecl_file = ecl_file_open("FOO.INIT", 0);
         BOOST_CHECK( ecl_file_has_kw(ecl_file, "STR_V") );
         ecl_kw_type * kw = ecl_file_iget_named_kw(ecl_file, "STR_V", 0);
-        test_assert_double_equal(67, ecl_kw_iget_as_double(kw, 2));
-        test_assert_double_equal(89, ecl_kw_iget_as_double(kw, 26));
+        BOOST_CHECK(67 == ecl_kw_iget_as_double(kw, 2));
+        BOOST_CHECK(89 == ecl_kw_iget_as_double(kw, 26));
 
 
         std::ifstream file( "FOO.UNRST", std::ios::binary );

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -317,16 +317,14 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
             { "TRANZ", { measure::transmissibility, tranz, TargetType::INIT } },
         };
 
-        std::map<std::string, std::vector<int> > int_data;
-        std::vector<int> u(27); u[2] = 67; u[5] = 89;
-        int_data["STR_ULONGNAME"] = u;
+        std::map<std::string, std::vector<int>> int_data =  {{"STR_ULONGNAME" , {1,1,1,1,1,1,1,1} } };
 
         std::vector<int> v(27); v[2] = 67; v[26] = 89;
         int_data["STR_V"] = v;
 
         eclWriter.writeInitial( );
 
-        test_assert_throw( eclWriter.writeInitial( eGridProps , int_data) , std::invalid_argument);
+        BOOST_CHECK_THROW( eclWriter.writeInitial( eGridProps , int_data) , std::invalid_argument);
 
         int_data.erase("STR_ULONGNAME");
         eclWriter.writeInitial( eGridProps , int_data );
@@ -357,7 +355,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         loadWells( "FOO.EGRID", "FOO.UNRST" );
 
         ecl_file_type * ecl_file = ecl_file_open("./FOO.INIT", 0);
-        test_assert_true( ecl_file_has_kw(ecl_file, "STR_V") );
+        BOOST_CHECK( ecl_file_has_kw(ecl_file, "STR_V") );
         ecl_kw_type * kw = ecl_file_iget_named_kw(ecl_file, "STR_V", 0);
         test_assert_double_equal(67, ecl_kw_iget_as_double(kw, 2));
         test_assert_double_equal(89, ecl_kw_iget_as_double(kw, 26));

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -317,19 +317,19 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
             { "TRANZ", { measure::transmissibility, tranz, TargetType::INIT } },
         };
 
-        std::map<std::string, std::vector<int> > map;
+        std::map<std::string, std::vector<int> > int_data;
         std::vector<int> u(27); u[2] = 67; u[5] = 89;
-        map["STR_ULONGNAME"] = u;
+        int_data["STR_ULONGNAME"] = u;
 
         std::vector<int> v(27); v[2] = 67; v[26] = 89;
-        map["STR_V"] = v;
+        int_data["STR_V"] = v;
 
         eclWriter.writeInitial( );
 
-        test_assert_throw( eclWriter.writeInitial( eGridProps , map) , std::invalid_argument);
+        test_assert_throw( eclWriter.writeInitial( eGridProps , int_data) , std::invalid_argument);
 
-        map.erase("STR_ULONGNAME");
-        eclWriter.writeInitial( eGridProps , map );
+        int_data.erase("STR_ULONGNAME");
+        eclWriter.writeInitial( eGridProps , int_data );
 
         data::Wells wells;
 


### PR DESCRIPTION
An extra argument of type std::map has been added to EclipseIO::writeInitial:
```C++
void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std::vector<int> > map, const NNC& nnc)
```
All entries in map will be written to INIT file in ecl keyword format. 

