### PR TITLE
Add support for GVPR+GVPT+GVPRT keywords

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -45,14 +45,17 @@ namespace Opm {
         public:
             Rates() = default;
             enum class opt : uint32_t {
-                wat           = (1 << 0),
-                oil           = (1 << 1),
-                gas           = (1 << 2),
-                polymer       = (1 << 3),
-                solvent       = (1 << 4),
-                energy        = (1 << 5),
-                dissolved_gas = (1 << 6),
-                vaporized_oil = (1 << 7),
+                wat               = (1 << 0),
+                oil               = (1 << 1),
+                gas               = (1 << 2),
+                polymer           = (1 << 3),
+                solvent           = (1 << 4),
+                energy            = (1 << 5),
+                dissolved_gas     = (1 << 6),
+                vaporized_oil     = (1 << 7),
+                reservoir_water   = (1 << 8),
+                reservoir_oil     = (1 << 9),
+                reservoir_gas     = (1 << 10),
             };
 
             using enum_size = std::underlying_type< opt >::type;
@@ -88,6 +91,9 @@ namespace Opm {
             double energy = 0.0;
             double dissolved_gas = 0.0;
             double vaporized_oil = 0.0;
+            double reservoir_water = 0.0;
+            double reservoir_oil = 0.0;
+            double reservoir_gas = 0.0;
     };
 
     struct Completion {
@@ -196,6 +202,9 @@ namespace Opm {
             case opt::energy: return this->energy;
             case opt::dissolved_gas: return this->dissolved_gas;
             case opt::vaporized_oil: return this->vaporized_oil;
+            case opt::reservoir_water: return this->reservoir_water;
+            case opt::reservoir_oil: return this->reservoir_oil;
+            case opt::reservoir_gas: return this->reservoir_gas;
         }
 
         throw std::invalid_argument(

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -344,6 +344,20 @@ inline quantity injection_history( const fn_args& args ) {
     return { sum, rate_unit< phase >() };
 }
 
+inline quantity res_vol_production_target( const fn_args& args ) {
+
+    if( args.timestep == 0 ) return { 0.0, measure::rate };
+
+    const auto timestep = args.timestep - 1;
+
+    double sum = 0.0;
+    for( const Well* sched_well : args.schedule_wells )
+        if (sched_well->getProductionProperties(timestep).predictionMode)
+            sum += sched_well->getProductionProperties( timestep ).ResVRate;
+
+    return { sum, measure::rate };
+}
+
 /*
  * A small DSL, really poor man's function composition, to avoid massive
  * repetition when declaring the handlers for each individual keyword. bin_op
@@ -716,6 +730,8 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "GGITH", mul( injection_history< Phase::GAS >, duration ) },
     { "GMWIN", flowing< injector > },
     { "GMWPR", flowing< producer > },
+
+    { "GVPRT", res_vol_production_target },
 
     { "CWIR", crate< rt::wat, injector > },
     { "CGIR", crate< rt::gas, injector > },

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -641,6 +641,8 @@ static const std::unordered_map< std::string, ofun > funs = {
                     duration ) },
     { "GLPT", mul( sum( rate< rt::wat, producer >, rate< rt::oil, producer > ),
                    duration ) },
+    { "GVPT", mul( sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
+                        rate< rt::reservoir_gas, producer > ), duration ) },
 
     { "WWPRH", production_history< Phase::WATER > },
     { "WOPRH", production_history< Phase::OIL > },

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -94,6 +94,10 @@ measure mul_unit( measure lhs, measure rhs ) {
         ( rhs == measure::gas_surface_rate && lhs == measure::time ) )
         return measure::gas_surface_volume;
 
+    if( ( lhs == measure::rate && rhs == measure::time ) ||
+        ( rhs == measure::rate && lhs == measure::time ) )
+        return measure::volume;
+
     return lhs;
 }
 
@@ -178,6 +182,15 @@ measure rate_unit< Phase::GAS >() { return measure::gas_surface_rate; }
 
 template<> constexpr
 measure rate_unit< rt::solvent >() { return measure::gas_surface_rate; }
+
+template<> constexpr
+measure rate_unit< rt::reservoir_water >() { return measure::rate; }
+
+template<> constexpr
+measure rate_unit< rt::reservoir_oil >() { return measure::rate; }
+
+template<> constexpr
+measure rate_unit< rt::reservoir_gas >() { return measure::rate; }
 
 template< rt phase, bool injection = true >
 inline quantity rate( const fn_args& args ) {
@@ -615,6 +628,8 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "GOPRS", rate< rt::vaporized_oil, producer > },
     { "GOPRF", sub (rate < rt::oil, producer >, rate< rt::vaporized_oil, producer > ) },
     { "GLPR", sum( rate< rt::wat, producer >, rate< rt::oil, producer > ) },
+    { "GVPR", sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
+                        rate< rt::reservoir_gas, producer > ) },
 
     { "GWPT", mul( rate< rt::wat, producer >, duration ) },
     { "GOPT", mul( rate< rt::oil, producer >, duration ) },

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -552,6 +552,7 @@ WELSPECS
      'W_1'        'G_1'   1    1  3.33       'OIL'  7* /
      'W_2'        'G_1'   2    1  3.33       'OIL'  7* /
      'W_3'        'G_2'   3    1  3.92       'WATER'  7* /
+     'W_5'        'G_3'   4    1  3.92       'OIL'  7* /
 /
 
 -- Completion data.
@@ -575,6 +576,10 @@ WCONHIST
 WCONINJH
 -- Injection historical rates (water only, as we only support pure injectors)
     W_3 WATER STOP 30.0 2.1 2.2 /
+/
+
+WCONPROD
+    W_5 SHUT ORAT 0.0 0.0 0.0 1* 30.1 /
 /
 
 TSTEP

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -138,6 +138,9 @@ static data::Wells result_wells() {
     rates1.set( rt::solvent, -10.3 / day );
     rates1.set( rt::dissolved_gas, -10.4 / day );
     rates1.set( rt::vaporized_oil, -10.5 / day );
+    rates1.set( rt::reservoir_water, -10.6 / day );
+    rates1.set( rt::reservoir_oil, -10.7 / day );
+    rates1.set( rt::reservoir_gas, -10.8 / day );
 
     data::Rates rates2;
     rates2.set( rt::wat, -20.0 / day );
@@ -146,6 +149,9 @@ static data::Wells result_wells() {
     rates2.set( rt::solvent, -20.3 / day );
     rates2.set( rt::dissolved_gas, -20.4 / day );
     rates2.set( rt::vaporized_oil, -20.5 / day );
+    rates2.set( rt::reservoir_water, -20.6 / day );
+    rates2.set( rt::reservoir_oil, -20.7 / day );
+    rates2.set( rt::reservoir_gas, -20.8 / day );
 
     data::Rates rates3;
     rates3.set( rt::wat, 30.0 / day );
@@ -154,6 +160,9 @@ static data::Wells result_wells() {
     rates3.set( rt::solvent, 30.3 / day );
     rates3.set( rt::dissolved_gas, 30.4 / day );
     rates3.set( rt::vaporized_oil, 30.5 / day );
+    rates3.set( rt::reservoir_water, 30.6 / day );
+    rates3.set( rt::reservoir_oil, 30.7 / day );
+    rates3.set( rt::reservoir_gas, 30.8 / day );
 
 
     /* completion rates */
@@ -164,6 +173,9 @@ static data::Wells result_wells() {
     crates1.set( rt::solvent, -100.3 / day );
     crates1.set( rt::dissolved_gas, -100.4 / day );
     crates1.set( rt::vaporized_oil, -100.5 / day );
+    crates1.set( rt::reservoir_water, -100.6 / day );
+    crates1.set( rt::reservoir_oil, -100.7 / day );
+    crates1.set( rt::reservoir_gas, -100.8 / day );
 
     data::Rates crates2;
     crates2.set( rt::wat, -200.0 / day );
@@ -172,6 +184,9 @@ static data::Wells result_wells() {
     crates2.set( rt::solvent, -200.3 / day );
     crates2.set( rt::dissolved_gas, -200.4 / day );
     crates2.set( rt::vaporized_oil, -200.5 / day );
+    crates2.set( rt::reservoir_water, -200.6 / day );
+    crates2.set( rt::reservoir_oil, -200.7 / day );
+    crates2.set( rt::reservoir_gas, -200.8 / day );
 
     data::Rates crates3;
     crates3.set( rt::wat, 300.0 / day );
@@ -180,6 +195,9 @@ static data::Wells result_wells() {
     crates3.set( rt::solvent, 300.3 / day );
     crates3.set( rt::dissolved_gas, 300.4 / day );
     crates3.set( rt::vaporized_oil, 300.5 / day );
+    crates2.set( rt::reservoir_water, 300.6 / day );
+    crates2.set( rt::reservoir_oil, 300.7 / day );
+    crates2.set( rt::reservoir_gas, 300.8 / day );
 
     /*
       The active index assigned to the completion must be manually
@@ -437,6 +455,8 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 10.5 + 20.5, ecl_sum_get_group_var( resp, 1, "G_1", "GOPRS" ), 1e-5 );
     BOOST_CHECK_CLOSE((10.1 - 10.5) + (20.1 - 20.5),
                                     ecl_sum_get_group_var( resp, 1, "G_1", "GOPRF" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.6 + 10.7 + 10.8 + 20.6 + 20.7 + 20.8,
+                                    ecl_sum_get_group_var( resp, 1, "G_1", "GVPR" ), 1e-5 );
 
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_group_var( resp, 1, "G_1", "GWPT" ), 1e-5 );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -498,6 +498,9 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
                                       ecl_sum_get_group_var( resp, 1, "G_1", "GLPTH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 0,             ecl_sum_get_group_var( resp, 1, "G_2", "GLPTH" ), 1e-5 );
 
+    /* Production targets */
+    BOOST_CHECK_CLOSE( 30.1 , ecl_sum_get_group_var( resp, 1, "G_3", "GVPRT" ), 1e-5 );
+
     /* Injection rates */
     BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_group_var( resp, 1, "G_2", "GGIR" ), 1e-5 );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -467,6 +467,8 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 10.5 + 20.5, ecl_sum_get_group_var( resp, 1, "G_1", "GOPTS" ), 1e-5 );
     BOOST_CHECK_CLOSE( (10.1 - 10.5) + (20.1 - 20.5), ecl_sum_get_group_var( resp, 1, "G_1", "GOPTF" ), 1e-5 );
     BOOST_CHECK_CLOSE( (10.2 - 10.4) + (20.2 - 20.4), ecl_sum_get_group_var( resp, 1, "G_1", "GGPTF" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.6 + 10.7 + 10.8 + 20.6 + 20.7 + 20.8,
+                                    ecl_sum_get_group_var( resp, 1, "G_1", "GVPT" ), 1e-5 );
     BOOST_CHECK_CLOSE(  2 * (10.0 + 20.0), ecl_sum_get_group_var( resp, 2, "G_1", "GWPT" ), 1e-5 );
     BOOST_CHECK_CLOSE(  2 * (10.1 + 20.1), ecl_sum_get_group_var( resp, 2, "G_1", "GOPT" ), 1e-5 );
     BOOST_CHECK_CLOSE(  2 * (10.2 + 20.2), ecl_sum_get_group_var( resp, 2, "G_1", "GGPT" ), 1e-5 );
@@ -475,6 +477,8 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE(  2 * (10.5 + 20.5), ecl_sum_get_group_var( resp, 2, "G_1", "GOPTS" ), 1e-5 );
     BOOST_CHECK_CLOSE(  2 * ((10.2 - 10.4) + (20.2 - 20.4)), ecl_sum_get_group_var( resp, 2, "G_1", "GGPTF" ), 1e-5 );
     BOOST_CHECK_CLOSE(  2 * ((10.1 - 10.5) + (20.1 - 20.5)), ecl_sum_get_group_var( resp, 2, "G_1", "GOPTF" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  2 * (10.6 + 10.7 + 10.8 + 20.6 + 20.7 + 20.8),
+                                    ecl_sum_get_group_var( resp, 2, "G_1", "GVPT" ), 1e-5 );
 
     /* Production rates (history) */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_group_var( resp, 1, "G_1", "GWPRH" ), 1e-5 );


### PR DESCRIPTION
Adds reservoir rates to Wells, to be populated from simulator (see issue https://github.com/OPM/opm-simulators/issues/1363 ).