### PR TITLE
Get block and region values from the simulator 

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -409,10 +409,10 @@ void EclipseIO::writeTimeStep(int report_step,
                               double secs_elapsed,
                               data::Solution cells,
                               data::Wells wells,
-                              const std::map<std::__cxx11::string, double>& single_summary_values,
-                              const std::map<std::__cxx11::string, std::vector<double> >& region_summary_values,
-                              const std::map<std::pair<std::__cxx11::string, int>, double>& block_summary_values,
-                              const std::map<std::__cxx11::string, std::vector<double>>&extra_restart,
+                              const std::map<std::string, double>& single_summary_values,
+                              const std::map<std::string, std::vector<double> >& region_summary_values,
+                              const std::map<std::pair<std::string, int>, double>& block_summary_values,
+                              const std::map<std::string, std::vector<double>>& extra_restart,
                               bool write_double)
  {
 
@@ -438,7 +438,6 @@ void EclipseIO::writeTimeStep(int report_step,
                                           es,
                                           schedule,
                                           wells ,
-                                          cells ,
                                           single_summary_values ,
                                           region_summary_values,
                                           block_summary_values);

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -401,13 +401,6 @@ void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std
             this->impl->writeEGRIDFile( nnc );
     }
 
-    this->impl->summary.set_initial( simProps );
-}
-
-
-void  EclipseIO::overwriteInitialOIP( const data::Solution& simProps )
-{
-    this->impl->summary.set_initial( simProps );
 }
 
 // implementation of the writeTimeStep method
@@ -419,7 +412,7 @@ void EclipseIO::writeTimeStep(int report_step,
                               std::map<std::string, double> misc_summary_values,
                               std::map<std::string, std::vector<double>> region_summary_values,
                               std::map<std::string, std::vector<double>> extra_restart,
-			      bool write_double)
+                              bool write_double)
  {
 
     if( !this->impl->output_enabled )

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -409,10 +409,10 @@ void EclipseIO::writeTimeStep(int report_step,
                               double secs_elapsed,
                               data::Solution cells,
                               data::Wells wells,
-                              std::map<std::string, double> single_summary_values,
-                              std::map<std::string, std::vector<double>> region_summary_values,
-                              std::map<std::pair<std::string, int>, double> block_summary_values,
-                              std::map<std::string, std::vector<double>> extra_restart,
+                              const std::map<std::__cxx11::string, double>& single_summary_values,
+                              const std::map<std::__cxx11::string, std::vector<double> >& region_summary_values,
+                              const std::map<std::pair<std::__cxx11::string, int>, double>& block_summary_values,
+                              const std::map<std::__cxx11::string, std::vector<double>>&extra_restart,
                               bool write_double)
  {
 

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -417,6 +417,7 @@ void EclipseIO::writeTimeStep(int report_step,
                               data::Solution cells,
                               data::Wells wells,
                               std::map<std::string, double> misc_summary_values,
+                              std::map<std::string, std::vector<double>> region_summary_values,
                               std::map<std::string, std::vector<double>> extra_restart,
 			      bool write_double)
  {
@@ -444,7 +445,8 @@ void EclipseIO::writeTimeStep(int report_step,
                                           schedule,
                                           wells ,
                                           cells ,
-                                          misc_summary_values );
+                                          misc_summary_values ,
+                                          region_summary_values);
         this->impl->summary.write();
     }
 

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -409,8 +409,9 @@ void EclipseIO::writeTimeStep(int report_step,
                               double secs_elapsed,
                               data::Solution cells,
                               data::Wells wells,
-                              std::map<std::string, double> misc_summary_values,
+                              std::map<std::string, double> single_summary_values,
                               std::map<std::string, std::vector<double>> region_summary_values,
+                              std::map<std::pair<std::string, int>, double> block_summary_values,
                               std::map<std::string, std::vector<double>> extra_restart,
                               bool write_double)
  {
@@ -438,8 +439,9 @@ void EclipseIO::writeTimeStep(int report_step,
                                           schedule,
                                           wells ,
                                           cells ,
-                                          misc_summary_values ,
-                                          region_summary_values);
+                                          single_summary_values ,
+                                          region_summary_values,
+                                          block_summary_values);
         this->impl->summary.write();
     }
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -176,6 +176,7 @@ public:
                         data::Solution,
                         data::Wells,
                         std::map<std::string, double> misc_summary_values,
+                        std::map<std::string, std::vector<double>> region_summary_values = {},
                         std::map<std::string, std::vector<double>> extra_restart = {},
 			bool write_double = false);
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -175,10 +175,10 @@ public:
                         double seconds_elapsed,
                         data::Solution,
                         data::Wells,
-                        std::map<std::string, double> single_summary_values,
-                        std::map<std::string, std::vector<double>> region_summary_values,
-                        std::map<std::pair<std::string, int>, double> block_summary_values = {},
-                        std::map<std::string, std::vector<double>> extra_restart = {},
+                        const std::map<std::string, double>& single_summary_values,
+                        const std::map<std::string, std::vector<double>>& region_summary_values,
+                        const std::map<std::pair<std::string, int>, double>& block_summary_values,
+                        const std::map<std::string, std::vector<double>>& extra_restart = {},
                         bool write_double = false);
 
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -176,7 +176,7 @@ public:
                         data::Solution,
                         data::Wells,
                         std::map<std::string, double> misc_summary_values,
-                        std::map<std::string, std::vector<double>> region_summary_values = {},
+                        std::map<std::string, std::vector<double>> region_summary_values,
                         std::map<std::string, std::vector<double>> extra_restart = {},
 			bool write_double = false);
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -175,10 +175,11 @@ public:
                         double seconds_elapsed,
                         data::Solution,
                         data::Wells,
-                        std::map<std::string, double> misc_summary_values,
+                        std::map<std::string, double> single_summary_values,
                         std::map<std::string, std::vector<double>> region_summary_values,
+                        std::map<std::pair<std::string, int>, double> block_summary_values = {},
                         std::map<std::string, std::vector<double>> extra_restart = {},
-			bool write_double = false);
+                        bool write_double = false);
 
 
     /*

--- a/opm/output/eclipse/RegionCache.cpp
+++ b/opm/output/eclipse/RegionCache.cpp
@@ -30,40 +30,23 @@
 namespace Opm {
 namespace out {
 
-    RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGrid& grid, const Schedule& schedule) {
-        const auto& fipnum = properties.getIntGridProperty("FIPNUM");
-        const auto& region_values = properties.getRegions( "FIPNUM" );
+RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGrid& grid, const Schedule& schedule) {
+    const auto& fipnum = properties.getIntGridProperty("FIPNUM");
 
-        for (auto region_id : region_values)
-            this->cell_map.emplace( region_id , fipnum.cellsEqual( region_id , grid ));
-
-
-        {
-            const auto& wells = schedule.getWells();
-            for (const auto& well : wells) {
-                const auto& completions = well->getCompletions( );
-                for (const auto& c : completions) {
-                    size_t global_index = grid.getGlobalIndex( c.getI() , c.getJ() , c.getK());
-                    if (grid.cellActive( global_index )) {
-                        size_t active_index = grid.activeIndex( global_index );
-                        int region_id =fipnum.iget( global_index );
-                        auto& well_index_list = this->completion_map[ region_id ];
-                        well_index_list.push_back( { well->name() , active_index } );
-                    }
-                }
+    const auto& wells = schedule.getWells();
+    for (const auto& well : wells) {
+        const auto& completions = well->getCompletions( );
+        for (const auto& c : completions) {
+            size_t global_index = grid.getGlobalIndex( c.getI() , c.getJ() , c.getK());
+            if (grid.cellActive( global_index )) {
+                size_t active_index = grid.activeIndex( global_index );
+                int region_id =fipnum.iget( global_index );
+                auto& well_index_list = this->completion_map[ region_id ];
+                well_index_list.push_back( { well->name() , active_index } );
             }
         }
     }
-
-
-    const std::vector<size_t>& RegionCache::cells( int region_id ) const {
-        const auto iter = this->cell_map.find( region_id );
-        if (iter == this->cell_map.end())
-            return this->cells_empty;
-        else
-            return iter->second;
-    }
-
+}
 
 
     const std::vector<std::pair<std::string,size_t>>& RegionCache::completions( int region_id ) const {

--- a/opm/output/eclipse/RegionCache.hpp
+++ b/opm/output/eclipse/RegionCache.hpp
@@ -32,14 +32,11 @@ namespace out {
     public:
         RegionCache() = default;
         RegionCache(const Eclipse3DProperties& properties, const EclipseGrid& grid, const Schedule& schedule);
-        const std::vector<size_t>& cells( int region_id ) const;
         const std::vector<std::pair<std::string,size_t>>& completions( int region_id ) const;
 
     private:
-        std::vector<size_t> cells_empty;
         std::vector<std::pair<std::string,size_t>> completions_empty;
 
-        std::map<int , std::vector<size_t> > cell_map;
         std::map<int , std::vector<std::pair<std::string,size_t>>> completion_map;
     };
 }

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -769,7 +769,7 @@ class Summary::keyword_handlers {
     public:
         using fn = ofun;
         std::vector< std::pair< smspec_node_type*, fn > > handlers;
-        std::map< std::string, smspec_node_type* > singel_value_nodes;
+        std::map< std::string, smspec_node_type* > single_value_nodes;
         std::map< std::pair <std::string, int>, smspec_node_type* > region_nodes;
         std::map< std::pair <std::string, int>, smspec_node_type* > block_nodes;
 
@@ -853,7 +853,7 @@ Summary::Summary( const EclipseState& st,
                                              st.getUnits().name( single_value_pair->second ),
                                              0 );
 
-            this->handlers->singel_value_nodes.emplace( keyword, nodeptr );
+            this->handlers->single_value_nodes.emplace( keyword, nodeptr );
         } else if (region_pair != region_units.end()) {
 
             auto* nodeptr = ecl_sum_add_var( this->ecl_sum.get(),
@@ -959,8 +959,8 @@ void Summary::add_timestep( int report_step,
 
     for( const auto& value_pair : single_values ) {
         const std::string key = value_pair.first;
-        const auto node_pair = this->handlers->singel_value_nodes.find( key );
-        if (node_pair != this->handlers->singel_value_nodes.end()) {
+        const auto node_pair = this->handlers->single_value_nodes.find( key );
+        if (node_pair != this->handlers->single_value_nodes.end()) {
             const auto * nodeptr = node_pair->second;
             const auto unit = single_values_units.at( key );
             double si_value = value_pair.second;

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -154,7 +154,6 @@ struct fn_args {
     size_t timestep;
     int  num;
     const data::Wells& wells;
-    const data::Solution& state;
     const out::RegionCache& regionCache;
     const EclipseGrid& grid;
 };
@@ -902,7 +901,6 @@ Summary::Summary( const EclipseState& st,
                                     0,           // Timestep number
                                     node.num(),  // NUMS value for the summary output.
                                     {},          // Well results - data::Wells
-                                    {},          // Solution::State
                                     {},          // Region <-> cell mappings.
                                     this->grid};
 
@@ -930,7 +928,6 @@ void Summary::add_timestep( int report_step,
                             const EclipseState& es,
                             const Schedule& schedule,
                             const data::Wells& wells ,
-                            const data::Solution& state,
                             const std::map<std::string, double>& single_values,
                             const std::map<std::string, std::vector<double>>& region_values,
                             const std::map<std::pair<std::string, int>, double>& block_values) {
@@ -949,7 +946,6 @@ void Summary::add_timestep( int report_step,
                                      timestep,
                                      num,
                                      wells,
-                                     state,
                                      this->regionCache,
                                      this->grid});
 

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -56,7 +56,8 @@ class Summary {
                            const Schedule& schedule,
                            const data::Wells&,
                            const data::Solution&,
-                           const std::map<std::string, double>& misc_values);
+                           const std::map<std::string, double>& misc_values,
+                           const std::map<std::string, std::vector<double>>& region_values = {});
 
         void set_initial( const data::Solution& );
         void write();

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -50,14 +50,15 @@ class Summary {
         Summary( const EclipseState&, const SummaryConfig&, const EclipseGrid&, const Schedule&, const std::string& );
         Summary( const EclipseState&, const SummaryConfig&, const EclipseGrid&, const Schedule&, const char* basename );
 
-        void add_timestep( int report_step,
+        void add_timestep(int report_step,
                            double secs_elapsed,
                            const EclipseState& es,
                            const Schedule& schedule,
                            const data::Wells&,
                            const data::Solution&,
-                           const std::map<std::string, double>& misc_values,
-                           const std::map<std::string, std::vector<double>>& region_values = {});
+                           const std::map<std::string, double>& single_values,
+                           const std::map<std::string, std::vector<double>>& region_values = {},
+                           const std::map<std::pair<std::string, int>, double>& block_values = {});
 
         void write();
 

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -30,8 +30,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <opm/output/data/Wells.hpp>
-#include <opm/output/data/Cells.hpp>
-#include <opm/output/data/Solution.hpp>
 #include <opm/output/eclipse/RegionCache.hpp>
 
 namespace Opm {
@@ -55,7 +53,6 @@ class Summary {
                            const EclipseState& es,
                            const Schedule& schedule,
                            const data::Wells&,
-                           const data::Solution&,
                            const std::map<std::string, double>& single_values,
                            const std::map<std::string, std::vector<double>>& region_values = {},
                            const std::map<std::pair<std::string, int>, double>& block_values = {});

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -59,7 +59,6 @@ class Summary {
                            const std::map<std::string, double>& misc_values,
                            const std::map<std::string, std::vector<double>>& region_values = {});
 
-        void set_initial( const data::Solution& );
         void write();
 
         ~Summary();
@@ -73,8 +72,6 @@ class Summary {
         std::unique_ptr< keyword_handlers > handlers;
         const ecl_sum_tstep_type* prev_tstep = nullptr;
         double prev_time_elapsed = 0;
-        double initial_oip = 0.0;
-        const std::vector<double> porv;
 };
 
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -343,6 +343,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 				     sol,
 				     wells,
                      {},
+                     {},
 				     {});
 				     
 

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -342,6 +342,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 				     first_step - start_time,
 				     sol,
 				     wells,
+                     {},
 				     {});
 				     
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -145,6 +145,7 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
                                      step_time - start_time,
                                      createBlackoilState( 2, numCells ),
                                      wells,
+        {},
 				     {});
     }
 
@@ -221,6 +222,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
                                              step_time - start_time,
                                              createBlackoilState( 2, numCells ),
                                              wells,
+                                             {},
                                              {});
             }
             verifyRFTFile2("TESTRFT.RFT");

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -146,6 +146,7 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
                                      createBlackoilState( 2, numCells ),
                                      wells,
         {},
+        {},
 				     {});
     }
 
@@ -222,6 +223,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
                                              step_time - start_time,
                                              createBlackoilState( 2, numCells ),
                                              wells,
+                                             {},
                                              {},
                                              {});
             }

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -363,7 +363,7 @@ RestartValue first_sim(const EclipseState& es, EclipseIO& eclWriter, bool write_
     eclWriter.writeTimeStep( 1,
                              false,
                              first_step - start_time,
-                             sol, wells , {}, {}, write_double);
+                             sol, wells , {}, {}, {}, write_double);
 
     return { sol, wells , {}};
 }

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -363,7 +363,7 @@ RestartValue first_sim(const EclipseState& es, EclipseIO& eclWriter, bool write_
     eclWriter.writeTimeStep( 1,
                              false,
                              first_step - start_time,
-                             sol, wells , {}, {}, {}, write_double);
+                             sol, wells , {}, {}, {}, {}, write_double);
 
     return { sol, wells , {}};
 }

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -51,13 +51,6 @@ BOOST_AUTO_TEST_CASE(create) {
     Schedule schedule( deck, grid, es.get3DProperties(), es.runspec().phases(), ParseContext() );
     out::RegionCache rc(es.get3DProperties() , grid, schedule);
 
-
-    const auto& c1 = rc.cells( 1 );
-    BOOST_CHECK_EQUAL( c1.size() , 100 );
-
-    const auto& c = rc.cells( 100 );
-    BOOST_CHECK_EQUAL( c.size() , 0 );
-
     {
         const auto& empty = rc.completions( 4 );
         BOOST_CHECK_EQUAL( empty.size() , 0 );

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -161,6 +161,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
                                      timestep,
                                      solution,
                                      wells ,
+                                      {},
 				     {} );
     }
 

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -161,8 +161,9 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
                                      timestep,
                                      solution,
                                      wells ,
-                                      {},
-				     {} );
+                                     {},
+                                     {},
+                                     {} );
     }
 
     verifyWellState(eclipse_restart_filename, grid, schedule);


### PR DESCRIPTION
Remove the computations in opm-output that depends on cell values. 

Motivation: 
Avoid duplication of code. 
Speed up MPI run. Now calculations are done locally and only the block, region and field values are communicated. 

Depends on downstream code. 