### PR TITLE
WIP:Include efficiency factor

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -30,7 +30,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/output/eclipse/RestartIO.hpp
         opm/output/eclipse/RestartValue.hpp
         opm/output/eclipse/Summary.hpp
-        opm/output/eclipse/Tables.hpp        
+        opm/output/eclipse/Tables.hpp
         opm/output/eclipse/RegionCache.hpp
         opm/output/data/Solution.hpp
         opm/test_util/EclFilesComparator.hpp
@@ -75,4 +75,5 @@ list (APPEND TEST_DATA_FILES
         tests/testrft.DATA
         tests/table_deck.DATA
         tests/summary_deck_non_constant_porosity.DATA
+        tests/SUMMARY_EFF_FAC.DATA
     )

--- a/tests/SUMMARY_EFF_FAC.DATA
+++ b/tests/SUMMARY_EFF_FAC.DATA
@@ -1,0 +1,138 @@
+START
+10 MAI 2007 /
+RUNSPEC
+
+TITLE
+SUMMARYTESTS
+
+-- A simple 10x10x10 cube. Simple to reason about, large enough for all tests
+DIMENS
+ 10 10 10 /
+
+REGDIMS
+  10 /
+
+OIL
+GAS
+WATER
+
+GRID
+
+DX
+1000*1 /
+DY
+1000*1 /
+DZ
+1000*1 /
+TOPS
+100*1 /
+
+
+PORO
+1000*0.2 /
+
+REGIONS
+
+FIPNUM
+ 1*2
+/
+
+SUMMARY
+DATE
+
+ROPR
+/
+
+RWIR
+/
+
+WOPR
+/
+WOPT
+/
+WOIR
+/
+WOIT
+/
+
+GOPR
+/
+GOPT
+/
+GOIR
+/
+GOIT
+/
+GWCT
+/
+GGOR
+/
+
+FOPR
+
+FOPT
+
+FOIR
+
+FOIT
+
+COPR
+'W_2' /
+/
+
+COPT
+'W_2' /
+/
+
+SCHEDULE
+
+GRUPTREE
+  'G_1'  'G' /
+  'G_2'  'G' /
+  'G_3'  'G_4' /
+/
+
+
+WELSPECS
+     'W_1'        'G_1'   1    1  3.33       'OIL'  7* /
+     'W_2'        'G_2'   2    1  3.33       'OIL'  7* /
+     'W_3'        'G_3'   2    1  3.33       'OIL'  7* /
+/
+
+WEFAC
+     'W_2' 0.2 /
+     'W_3' 0.3 /
+/
+
+GEFAC
+    G_2 0.01 /
+    G_3 0.02 /
+    G_4 0.03 /
+/
+
+WCONPROD
+    W_1 'OPEN' ORAT 10.1 /
+    W_2 'OPEN' ORAT 10.1 /
+    W_3 'OPEN' ORAT 10.1 /
+/
+
+-- Completion data.
+COMPDAT
+-- 'Well' I J K1 K2
+-- Passing 0 to I/J means they'll get the well head I/J
+   W_1 0 0 1 1 /   -- Active index: 0
+   W_2 0 0 1 1 /   -- Active index: 1
+   W_2 0 0 2 2 /   -- Active index: 101
+   W_3 0 0 1 1 /   -- Active index: 2
+/
+
+TSTEP
+-- register time steps (in days). This allows us to write *two* report steps (1
+-- and 2. Without this, totals/accumulations would fail (segfault) when looking
+-- up historical rates and volumes. These volumes however don't change, i.e.
+-- every time step has the same set of values
+10 10 /
+
+
+TSTEP
+10 10 /

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -135,9 +135,9 @@ static data::Wells result_wells() {
     crates3.set( rt::solvent, 300.3 / day );
     crates3.set( rt::dissolved_gas, 300.4 / day );
     crates3.set( rt::vaporized_oil, 300.5 / day );
-    crates2.set( rt::reservoir_water, 300.6 / day );
-    crates2.set( rt::reservoir_oil, 300.7 / day );
-    crates2.set( rt::reservoir_gas, 300.8 / day );
+    crates3.set( rt::reservoir_water, 300.6 / day );
+    crates3.set( rt::reservoir_oil, 300.7 / day );
+    crates3.set( rt::reservoir_gas, 300.8 / day );
 
     /*
       The global index assigned to the completion must be manually

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1150,3 +1150,75 @@ BOOST_AUTO_TEST_CASE(READ_WRITE_WELLDATA) {
             BOOST_CHECK_CLOSE( wellRatesCopy.get( "W_2" , 101 , rt::wat) , wellRates.get( "W_2" , 101 , rt::wat), 1e-16);
 
 }
+
+BOOST_AUTO_TEST_CASE(efficiency_factor) {
+        setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA" );
+
+        out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+        writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.write();
+        auto res = readsum( cfg.name );
+        const auto* resp = res.get();
+
+        /* No WEFAC assigned to W_1 */
+        BOOST_CHECK_CLOSE( 10.1, ecl_sum_get_well_var( resp, 1, "W_1", "WOPR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 10.1, ecl_sum_get_well_var( resp, 1, "W_1", "WOPT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 10.1, ecl_sum_get_well_var( resp, 2, "W_1", "WOPT" ), 1e-5 );
+
+        /* WEFAC 0.2 assigned to W_2.
+         * W_2 assigned to group G2. GEFAC G2 = 0.01 */
+        BOOST_CHECK_CLOSE( 20.1, ecl_sum_get_well_var( resp, 1, "W_2", "WOPR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 20.1 * 0.2 * 0.01, ecl_sum_get_well_var( resp, 1, "W_2", "WOPT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 20.1 * 0.2 * 0.01, ecl_sum_get_well_var( resp, 2, "W_2", "WOPT" ), 1e-5 );
+
+        /* WEFAC 0.3 assigned to W_3.
+         * W_3 assigned to group G3. GEFAC G_3 = 0.02
+         * G_3 assigned to group G4. GEFAC G_4 = 0.03*/
+        BOOST_CHECK_CLOSE( 30.1, ecl_sum_get_well_var( resp, 1, "W_3", "WOIR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_well_var( resp, 1, "W_3", "WOIT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_well_var( resp, 2, "W_3", "WOIT" ), 1e-5 );
+
+        /* WEFAC 0.2 assigned to W_2.
+         * W_2 assigned to group G2. GEFAC G2 = 0.01 */
+        BOOST_CHECK_CLOSE( 20.1 * 0.2, ecl_sum_get_group_var( resp, 1, "G_2", "GOPR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 20.1 * 0.2 * 0.01, ecl_sum_get_group_var( resp, 1, "G_2", "GOPT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 20.1 * 0.2 * 0.01, ecl_sum_get_group_var( resp, 2, "G_2", "GOPT" ), 1e-5 );
+
+        /* WEFAC 0.3 assigned to W_3.
+         * W_3 assigned to group G3. GEFAC G_3 = 0.02
+         * G_3 assigned to group G4. GEFAC G_4 = 0.03*/
+        BOOST_CHECK_CLOSE( 30.1 * 0.3, ecl_sum_get_group_var( resp, 1, "G_3", "GOIR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_group_var( resp, 1, "G_3", "GOIT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_group_var( resp, 2, "G_3", "GOIT" ), 1e-5 );
+
+        /* WEFAC 0.3 assigned to W_3.
+         * W_3 assigned to group G3. GEFAC G_3 = 0.02
+         * G_3 assigned to group G4. GEFAC G_4 = 0.03
+         * The rate for a group is calculated including WEFAC and GEFAC for subgroups */
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02, ecl_sum_get_group_var( resp, 1, "G_4", "GOIR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_group_var( resp, 1, "G_4", "GOIT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_group_var( resp, 2, "G_4", "GOIT" ), 1e-5 );
+
+        BOOST_CHECK_CLOSE( 10.1 + 20.1 * 0.2 * 0.01, ecl_sum_get_field_var( resp, 1, "FOPR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 10.1 + 20.1 * 0.2 * 0.01, ecl_sum_get_field_var( resp, 1, "FOPT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * (10.1 + 20.1 * 0.2 * 0.01), ecl_sum_get_field_var( resp, 2, "FOPT" ), 1e-5 );
+
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 1, "FOIR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 1, "FOIT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 2, "FOIT" ), 1e-5 );
+
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 1, "FOIR" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 1, "FOIT" ), 1e-5 );
+        BOOST_CHECK_CLOSE( 2 * 30.1 * 0.3 * 0.02 * 0.03, ecl_sum_get_field_var( resp, 2, "FOIT" ), 1e-5 );
+
+        BOOST_CHECK_CLOSE( 200.1 * 0.2 * 0.01, ecl_sum_get_general_var( resp , 1 , "ROPR:1" ) , 1e-5);
+
+        BOOST_CHECK_CLOSE( 100.1, ecl_sum_get_general_var( resp , 1 , "ROPR:2" ) , 1e-5);
+
+        BOOST_CHECK_CLOSE( 300 * 0.2 * 0.01, ecl_sum_get_general_var( resp , 1 , "RWIR:1" ) , 1e-5);
+
+        BOOST_CHECK_CLOSE( 200.1, ecl_sum_get_well_completion_var( resp, 1, "W_2", "COPR", 2 ), 1e-5 );
+        BOOST_CHECK_CLOSE( 200.1 * 0.2 * 0.01, ecl_sum_get_well_completion_var( resp, 1, "W_2", "COPT", 2 ), 1e-5 );
+}


### PR DESCRIPTION
Efficiency factors are multiplied when specified at multiple levels of the well/group hierarchy.
   
The factors are included as follows:
  * Well Rate (e.g. WOPR)    - No efficiency factor
  * Well Total (e.g. WOPT)   - WEFAC & GEFAC (whole hierarchy)
  * Group Rate (e.g. GOPR)   - WEFAC & GEFAC (only subgroups)
  * Group Total (e.g. GOPT)  - WEFAC & GEFAC (whole hierarchy)
  * Field Rate (e.g. FOPR)   - WEFAC & GEFAC (whole hierarchy)
  * Field Total (e.g. FOPT)  - WEFAC & GEFAC (whole hierarchy)
  * Region Rate (e.g. ROPR)  - WEFAC & GEFAC (whole hierarchy)
  * Region Total (e.g. ROPT) - WEFAC & GEFAC (whole hierarchy)

Ref #236 