### PR TITLE
adding a few summary keywords

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -436,6 +436,7 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "WOPRF", sub (rate < rt::oil, producer >, rate< rt::vaporized_oil, producer > )  },
     { "WVPR", sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
                    rate< rt::reservoir_gas, producer > ) },
+    { "WGVPR", rate< rt::reservoir_gas, producer > },
 
     { "WLPR", sum( rate< rt::wat, producer >, rate< rt::oil, producer > ) },
     { "WWPT", mul( rate< rt::wat, producer >, duration ) },
@@ -468,6 +469,8 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "WVPRT", res_vol_production_target },
 
     { "GWIR", rate< rt::wat, injector > },
+    { "WGVIR", rate< rt::reservoir_gas, injector >},
+    { "WWVIR", rate< rt::reservoir_water, injector >},
     { "GOIR", rate< rt::oil, injector > },
     { "GGIR", rate< rt::gas, injector > },
     { "GNIR", rate< rt::solvent, injector > },

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -331,6 +331,8 @@ WWPRH
 /
 WOPR
 /
+WGVPR
+ W_1 W_2 /
 WOPRH
 /
 WGPR
@@ -364,6 +366,12 @@ WWIT
  W_3
 /
 WWIRH
+  W_3
+/
+WGVIR
+  W_3
+/
+WWVIR
   W_3
 /
 WWITH

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -233,7 +233,9 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( 20.1, ecl_sum_get_well_var( resp, 1, "W_2", "WOPR" ), 1e-5 );
 
     BOOST_CHECK_CLOSE( 10.2, ecl_sum_get_well_var( resp, 1, "W_1", "WGPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.8, ecl_sum_get_well_var( resp, 1, "W_1", "WGVPR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 20.2, ecl_sum_get_well_var( resp, 1, "W_2", "WGPR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.8, ecl_sum_get_well_var( resp, 1, "W_2", "WGVPR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 10.0 + 10.1, ecl_sum_get_well_var( resp, 1, "W_1", "WLPR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 20.0 + 20.1, ecl_sum_get_well_var( resp, 1, "W_2", "WLPR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 10.3, ecl_sum_get_well_var( resp, 1, "W_1", "WNPR" ), 1e-5 );
@@ -316,6 +318,8 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
 
     /* Injection rates */
     BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_well_var( resp, 1, "W_3", "WWIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.6, ecl_sum_get_well_var( resp, 1, "W_3", "WWVIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.8, ecl_sum_get_well_var( resp, 1, "W_3", "WGVIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_well_var( resp, 1, "W_3", "WGIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.3, ecl_sum_get_well_var( resp, 1, "W_3", "WNIR" ), 1e-5 );
 


### PR DESCRIPTION
WWVIR, WGVPR and WGVIR. It depends on OPM/opm-parser#1211

I am not sure why the test fails, maybe the maintainer can help to give some hints about it. 

```
test 7
    Start 7: test_Summary

7: Test command: /home/kaib/OPM-PR-test/debug/opm-output-build/bin/test_Summary
7: Test timeout computed to be: 1500
7: 
7: Error message: ecl_sum_tstep_iget: param index:-1 invalid: Valid range: [0,654) 
7: 
7: See file: /tmp/ert_abort_dump.kaib.20180213-162937.log for more details of the crash.
7: Setting the environment variable "ERT_SHOW_BACKTRACE" will show the backtrace on stderr.
7: Running 14 test cases...
1/1 Test #7: test_Summary .....................***Exception: Other  0.27 sec
```
