### PR TITLE
test_LinearisedOutputTable: include config.h unconditionally

### DIFF
--- a/tests/test_LinearisedOutputTable.cpp
+++ b/tests/test_LinearisedOutputTable.cpp
@@ -16,10 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#if defined(HAVE_CONFIG_H)
-#include <config.h>
-#endif  // defined(HAVE_CONFIG_H)
+#include "config.h"
 
 #define NVERBOSE
 


### PR DESCRIPTION
this is already the case for the vast majority of the other OPM code.